### PR TITLE
refactor: update typography class names

### DIFF
--- a/.nx/version-plans/version-plan-1753974975115.md
+++ b/.nx/version-plans/version-plan-1753974975115.md
@@ -1,0 +1,6 @@
+---
+'@ldls/design-core': patch
+'@ldls/ui-react': patch
+---
+
+Fix typography classes

--- a/libs/design-core/src/utils/create-custom-plugin.ts
+++ b/libs/design-core/src/utils/create-custom-plugin.ts
@@ -91,7 +91,7 @@ export function createTypographyPlugin() {
         'line-height': 'var(--font-style-heading-1-line-height)',
         'letter-spacing': 'var(--font-style-heading-1-letter-spacing)',
       },
-      '.heading-1-medium': {
+      '.heading-1-semi-bold': {
         'font-family': 'var(--font-family-font)',
         'font-size': 'var(--font-style-heading-1-size)',
         'font-weight': 'var(--font-style-heading-1-weight-medium)',
@@ -101,42 +101,42 @@ export function createTypographyPlugin() {
       '.heading-2': {
         'font-family': 'var(--font-family-font)',
         'font-size': 'var(--font-style-heading-2-size)',
-        'font-weight': 'var(--font-style-heading-2-weight-semi-bold)',
+        'font-weight': 'var(--font-style-heading-2-weight-medium)',
         'line-height': 'var(--font-style-heading-2-line-height)',
         'letter-spacing': 'var(--font-style-heading-2-letter-spacing)',
       },
-      '.heading-2-medium': {
+      '.heading-2-semi-bold': {
         'font-family': 'var(--font-family-font)',
         'font-size': 'var(--font-style-heading-2-size)',
-        'font-weight': 'var(--font-style-heading-2-weight-medium)',
+        'font-weight': 'var(--font-style-heading-2-weight-semi-bold)',
         'line-height': 'var(--font-style-heading-2-line-height)',
         'letter-spacing': 'var(--font-style-heading-2-letter-spacing)',
       },
       '.heading-3': {
         'font-family': 'var(--font-family-font)',
         'font-size': 'var(--font-style-heading-3-size)',
-        'font-weight': 'var(--font-style-heading-3-weight-semi-bold)',
+        'font-weight': 'var(--font-style-heading-3-weight-medium)',
         'line-height': 'var(--font-style-heading-3-line-height)',
         'letter-spacing': 'var(--font-style-heading-3-letter-spacing)',
       },
-      '.heading-3-medium': {
+      '.heading-3-semi-bold': {
         'font-family': 'var(--font-family-font)',
         'font-size': 'var(--font-style-heading-3-size)',
-        'font-weight': 'var(--font-style-heading-3-weight-medium)',
+        'font-weight': 'var(--font-style-heading-3-weight-semi-bold)',
         'line-height': 'var(--font-style-heading-3-line-height)',
         'letter-spacing': 'var(--font-style-heading-3-letter-spacing)',
       },
       '.heading-4': {
         'font-family': 'var(--font-family-font)',
         'font-size': 'var(--font-style-heading-4-size)',
-        'font-weight': 'var(--font-style-heading-4-weight-semi-bold)',
+        'font-weight': 'var(--font-style-heading-4-weight-medium)',
         'line-height': 'var(--font-style-heading-4-line-height)',
         'letter-spacing': 'var(--font-style-heading-4-letter-spacing)',
       },
-      '.heading-4-medium': {
+      '.heading-4-semi-bold': {
         'font-family': 'var(--font-family-font)',
         'font-size': 'var(--font-style-heading-4-size)',
-        'font-weight': 'var(--font-style-heading-4-weight-medium)',
+        'font-weight': 'var(--font-style-heading-4-weight-semi-bold)',
         'line-height': 'var(--font-style-heading-4-line-height)',
         'letter-spacing': 'var(--font-style-heading-4-letter-spacing)',
       },

--- a/libs/ui-react/src/lib/Components/Design-tokens/styles/typography.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Design-tokens/styles/typography.stories.tsx
@@ -17,12 +17,13 @@ const TypographySample = ({
 }) => (
   <div>
     <div
-      className={`${className} toto max-w-fit rounded-lg border border-muted-subtle p-24 text-base`}
+      className={`${className} max-w-fit rounded-lg border border-muted-subtle bg-base p-24 text-base`}
     >
       The quick brown fox jumps over the lazy dog
+      <div className="mt-24 bg-muted-pressed p-[0.5px]" />
+      <div className="mb-4 mt-16 text-base body-2"> {title} </div>
+      <div className="text-muted body-4">{className}</div>
     </div>
-    <div className="mb-4 mt-16 text-base body-2">{title}</div>
-    <div className="mb-32 text-muted body-4">{className}</div>
   </div>
 );
 
@@ -33,11 +34,13 @@ const TypographyShowcase = () => {
     { className: 'display-3', title: 'Display 3' },
     { className: 'display-4', title: 'Display 4' },
     { className: 'heading-1', title: 'Heading 1' },
-    { className: 'heading-1-medium', title: 'Heading 1 Medium' },
+    { className: 'heading-1-semi-bold', title: 'Heading 1 Semi Bold' },
     { className: 'heading-2', title: 'Heading 2' },
-    { className: 'heading-2-medium', title: 'Heading 2 Medium' },
+    { className: 'heading-2-semi-bold', title: 'Heading 2 Semi Bold' },
     { className: 'heading-3', title: 'Heading 3' },
-    { className: 'heading-3-medium', title: 'Heading 3 Medium' },
+    { className: 'heading-3-semi-bold', title: 'Heading 3 Semi Bold' },
+    { className: 'heading-4', title: 'Heading 4' },
+    { className: 'heading-4-semi-bold', title: 'Heading 4 Semi Bold' },
     { className: 'body-1', title: 'Body 1' },
     { className: 'body-1-semi-bold', title: 'Body 1 Semi Bold' },
     { className: 'body-2', title: 'Body 2' },

--- a/libs/ui-react/src/lib/tailwind-preset.mdx
+++ b/libs/ui-react/src/lib/tailwind-preset.mdx
@@ -83,7 +83,7 @@ Pre-configured typography classes that handle font family, size, weight, line he
 
 // Headings
 <h2 className="heading-1">Main Heading</h2>
-<h3 className="heading-2-medium">Section Title</h3>
+<h3 className="heading-2-semi-bold">Section Title</h3>
 
 // Body Text
 <p className="body-1">Regular paragraph text</p>


### PR DESCRIPTION

- Renamed typography class names from 'medium' to 'semi-bold' for better alignment with design standards.
- Updated corresponding references in the documentation and story files to reflect the new class names.