### PR TITLE
feat:  Introduced the `asChild` prop to the Button component

### DIFF
--- a/libs/ui-react/src/lib/Components/Button/Button.mdx
+++ b/libs/ui-react/src/lib/Components/Button/Button.mdx
@@ -100,3 +100,23 @@ To be implemented:
 ### Interactive States
 
 <Canvas of={ButtonStories.InteractiveLoadingStates} />
+
+### As Child
+
+<Canvas of={ButtonStories.AsChild} />
+
+<div className="rounded-8 mt-8 bg-muted p-12">
+  <p className="mb-4 body-2-semi-bold">Important Notes:</p>
+  <ul className="space-y-2 body-2">
+    <li>When using asChild, the child element receives all button styles</li>
+    <li>
+      Icon and loading props are ignored with asChild - handle these in the
+      child element
+    </li>
+    <li>Perfect for navigation links that should look like buttons</li>
+    <li>
+      Maintains semantic HTML (e.g., &lt;a&gt; for links, &lt;button&gt; for
+      actions)
+    </li>
+  </ul>
+</div>

--- a/libs/ui-react/src/lib/Components/Button/Button.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Button/Button.stories.tsx
@@ -55,6 +55,15 @@ const meta: Meta<typeof Button> = {
       control: 'text',
       description: 'The content to be displayed inside the button',
     },
+    isFull: {
+      control: 'boolean',
+      description: 'Whether the button is full width',
+    },
+    asChild: {
+      control: 'boolean',
+      description:
+        'Render as child element instead of button (useful for links)',
+    },
   },
 };
 
@@ -276,5 +285,62 @@ export const InteractiveLoadingStates: Story = {
         />
       </div>
     );
+  },
+};
+
+export const AsChild: Story = {
+  render: () => {
+    // Mock Link component for demonstration
+    const Link = ({
+      to,
+      children,
+      ...props
+    }: {
+      to: string;
+      children: React.ReactNode;
+    } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+      <a href={to} {...props}>
+        {children}
+      </a>
+    );
+
+    return (
+      <div className="flex flex-col gap-16 p-8">
+        <div className="flex gap-8">
+          <Button asChild appearance="base">
+            <Link to="#">Open Button documentation</Link>
+          </Button>
+
+          <Button asChild appearance="accent">
+            <a
+              href="https://shop.ledger.com"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              External Link to Ledger Shop
+            </a>
+          </Button>
+        </div>
+      </div>
+    );
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `
+// Button as a router link
+<Button asChild appearance="base" size="md">
+  <Link to="/dashboard">Go to Dashboard</Link>
+</Button>
+
+// Button as an external link
+<Button asChild appearance="accent" size="sm">
+  <a href="https://example.com" target="_blank" rel="noopener noreferrer">
+    External Link
+  </a>
+</Button>
+`,
+      },
+    },
   },
 };

--- a/libs/ui-react/src/lib/Components/Button/Button.tsx
+++ b/libs/ui-react/src/lib/Components/Button/Button.tsx
@@ -3,6 +3,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@ldls/utils-shared';
 import { Spinner } from '../../Symbols/Icons/Spinner';
 import { IconSize } from '../Icon/Icon';
+import { Slot } from '@radix-ui/react-slot';
 
 const buttonVariants = cva(
   'inline-flex h-fit w-fit cursor-pointer items-center justify-center rounded-full transition-colors body-1-semi-bold focus-visible:outline-focus focus-visible:ring-2 disabled:pointer-events-none disabled:bg-disabled disabled:text-disabled',
@@ -29,7 +30,7 @@ const buttonVariants = cva(
         true: 'w-full',
       },
       loading: {
-        true: '',
+        true: 'pointer-events-none',
       },
       iconOnly: {
         true: '',
@@ -75,6 +76,7 @@ export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   icon?: React.ComponentType<{ size?: IconSize; className?: string }>;
+  asChild?: boolean;
 }
 
 /**
@@ -92,6 +94,8 @@ export interface ButtonProps
  * @param {boolean} [loading=false] - If true, shows a loading spinner and disables the button.
  * @param {React.ComponentType<{ size?: IconSize; className?: string }>} [icon] - An optional icon component to render inside the button.
  *   The icon styles are defined by the button. Please do not override them.
+ * @param {boolean} [asChild=false] - If true, renders the child element directly with button styles instead of wrapping in a button element.
+ *   Useful for creating link buttons or other semantic elements with button appearance.
  * @param {string} [className] - Additional custom CSS classes to apply. Do not use this prop to modify the component's core appearance - use the `appearance` prop instead.
  * @param {React.ReactNode} [children] - The button's content, typically text or other elements.
  * @param {React.ButtonHTMLAttributes<HTMLButtonElement>} [...] - All standard button props (e.g., `disabled`, `onClick`, `type`).
@@ -117,6 +121,24 @@ export interface ButtonProps
  * <Button appearance="accent" isFull={true} className="ml-16">
  *   Submit
  * </Button>
+ *
+ * // Button as a link (asChild pattern)
+ * import { Link } from 'react-router-dom';
+ *
+ * <Button asChild appearance="base" size="md">
+ *   <Link to="/dashboard">Go to Dashboard</Link>
+ * </Button>
+ *
+ * // Button as an anchor tag
+ * <Button asChild appearance="accent" size="sm">
+ *   <a href="https://example.com" target="_blank" rel="noopener noreferrer">
+ *     External Link
+ *   </a>
+ * </Button>
+ *
+ * // Note: When using asChild, the child element is responsible for its own content.
+ * // Icons, loading states, and other Button props like 'icon' and 'loading' are ignored
+ * // when asChild is true - you should handle these in the child element if needed.
  */
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   (
@@ -128,6 +150,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       isFull,
       loading,
       icon,
+      asChild = false,
       ...props
     },
     ref,
@@ -144,8 +167,10 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const calculatedIconSize = size ? iconSizeMap[size] : 24;
     const IconComponent = icon;
 
+    const Comp = asChild ? Slot : 'button';
+
     return (
-      <button
+      <Comp
         ref={ref}
         className={cn(
           className,
@@ -160,31 +185,37 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         disabled={props.disabled}
         {...props}
       >
-        {loading ? (
-          <>
-            <Spinner
-              size={calculatedIconSize}
-              className="flex-shrink-0 animate-spin"
-              aria-label="Loading"
-            />
-            {children && (
-              <span className="line-clamp-2 text-left">{children}</span>
-            )}
-          </>
+        {asChild ? (
+          children
         ) : (
           <>
-            {IconComponent && (
-              <IconComponent
-                size={calculatedIconSize}
-                className="flex-shrink-0"
-              />
-            )}
-            {children && (
-              <span className="line-clamp-2 text-left">{children}</span>
+            {loading ? (
+              <>
+                <Spinner
+                  size={calculatedIconSize}
+                  className="flex-shrink-0 animate-spin"
+                  aria-label="Loading"
+                />
+                {children && (
+                  <span className="line-clamp-2 text-left">{children}</span>
+                )}
+              </>
+            ) : (
+              <>
+                {IconComponent && (
+                  <IconComponent
+                    size={calculatedIconSize}
+                    className="flex-shrink-0"
+                  />
+                )}
+                {children && (
+                  <span className="line-clamp-2 text-left">{children}</span>
+                )}
+              </>
             )}
           </>
         )}
-      </button>
+      </Comp>
     );
   },
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "libs/*"
       ],
       "dependencies": {
+        "@radix-ui/react-slot": "^1.2.3",
         "ajv": "^8.17.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -6647,6 +6648,37 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@react-native-community/cli": {
       "version": "15.0.1",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {},
   "private": true,
   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3",
     "ajv": "^8.17.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
- Introduced the `asChild` prop to the Button component, allowing it to render a child element with button styles instead of wrapping it in a button element.
- Updated Button documentation and stories to demonstrate usage of the `asChild` prop.
- Added `@radix-ui/react-slot` as a dependency for handling child elements.