### PR TITLE
ci: migrate runner to github

### DIFF
--- a/.github/workflows/release-all.yml
+++ b/.github/workflows/release-all.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   release:
-    runs-on: ledgerhq-shared-small
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:


### PR DESCRIPTION
Since the repository is now public, we should use a github runner instead.