### PR TITLE
feat: add Input component with implementation, documentation, and tests

### DIFF
--- a/.nx/version-plans/version-plan-1756814561043.md
+++ b/.nx/version-plans/version-plan-1756814561043.md
@@ -1,0 +1,5 @@
+---
+'@ldls/ui-react': patch
+---
+
+Introduce new Input component

--- a/libs/ui-react/.storybook/preview.ts
+++ b/libs/ui-react/.storybook/preview.ts
@@ -65,6 +65,8 @@ const preview: Preview = {
             ['Implementation', 'Docs', '*'],
             'CardButton',
             ['Implementation', 'Docs', '*'],
+            'Input',
+            ['Implementation', 'Docs', '*'],
           ],
         ],
       },

--- a/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
+++ b/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
@@ -80,7 +80,11 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
         ? true
         : undefined;
 
-    const hasContent = !!props.value && props.value.toString().length > 0;
+    const isControlled = props.value !== undefined;
+    const hasContent = isControlled
+      ? !!props.value && props.value.toString().length > 0
+      : !!inputRef.current?.value;
+
     const showClearButton = hasContent && !disabled && onClear;
 
     const errorId = `${inputId}-error`;

--- a/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
+++ b/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
@@ -159,7 +159,16 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
             /** TODO: extract to a new component IconButton */
             <button
               type="button"
-              onClick={onClear}
+              onClick={() => {
+                if (isControlled) {
+                  onClear?.();
+                } else if (inputRef.current) {
+                  inputRef.current.value = '';
+                  const event = new Event('input', { bubbles: true });
+                  inputRef.current.dispatchEvent(event);
+                  onClear?.();
+                }
+              }}
               className="mr-16 cursor-pointer rounded-full"
               aria-label="Clear input"
               data-side="right"

--- a/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
+++ b/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { cn } from '@ldls/utils-shared';
 import { DeleteCircleFill } from '../../Symbols';
 
-const baseRootStyles = cn(
+const baseContainerStyles = cn(
   'group relative flex h-48 w-full items-center gap-8 px-16 rounded-md bg-muted transition-colors',
   'hover:bg-muted-hover focus-within:ring-2 focus-within:ring-active',
   'has-[:disabled]:pointer-events-none has-[:disabled]:cursor-not-allowed has-[:disabled]:bg-disabled has-[:disabled]:text-disabled',
@@ -119,7 +119,7 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
         // Always call the original onChange if provided
         onChangeProp?.(e);
       },
-      [isControlled, this, onChangeProp],
+      [isControlled, onChangeProp],
     );
 
     const hasContent = isControlled
@@ -170,7 +170,7 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
     return (
       <div>
         <div
-          className={cn(containerClassName, baseRootStyles)}
+          className={cn(containerClassName, baseContainerStyles)}
           onPointerDown={(event: React.PointerEvent<HTMLDivElement>) => {
             const target = event.target as Element;
             if (target.closest('input, button, a')) return;

--- a/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
+++ b/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
@@ -70,7 +70,8 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
   ) => {
     const inputRef = React.useRef<HTMLInputElement>(null);
 
-    const inputId = id || `input-${Math.random().toString(36).slice(2, 11)}`;
+    const reactId = React.useId();
+    const inputId = id || `input-${reactId}`;
 
     // Handle aria-invalid properly - use provided value or derive from errorMessage
     const ariaInvalid = props['aria-invalid']

--- a/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
+++ b/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
@@ -3,7 +3,7 @@ import { cn } from '@ldls/utils-shared';
 import { DeleteCircleFill } from '../../Symbols';
 
 const baseRootStyles = cn(
-  'group relative flex h-48 w-full items-center rounded-md bg-muted transition-colors',
+  'group relative flex h-48 w-full items-center gap-8 px-16 rounded-md bg-muted transition-colors',
   'hover:bg-muted-hover focus-within:ring-2 focus-within:ring-active',
   'has-[:disabled]:pointer-events-none has-[:disabled]:cursor-not-allowed has-[:disabled]:bg-disabled has-[:disabled]:text-disabled',
   'has-[:invalid]:ring-1 has-[:invalid]:ring-error has-[:invalid]:border-error',
@@ -11,7 +11,7 @@ const baseRootStyles = cn(
 );
 
 const baseInputStyles = cn(
-  'peer flex-1 bg-transparent pl-16 text-base outline-none body-2 transition-colors bg-muted rounded-md',
+  'peer flex-1 bg-transparent w-full text-base outline-none body-2 transition-colors bg-muted ',
   'group-hover:bg-muted-hover group-disabled:bg-disabled',
   'group-has-[:disabled]:pointer-events-none group-has-[:disabled]:cursor-not-allowed group-has-[:disabled]:bg-disabled group-has-[:disabled]:text-disabled',
   'placeholder:text-transparent',
@@ -170,11 +170,7 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
             });
           }}
         >
-          {prefix && (
-            <div data-side="left" className="ml-16">
-              {prefix}
-            </div>
-          )}
+          {prefix && <div data-side="left">{prefix}</div>}
 
           <input
             ref={composeRefs(ref, inputRef)}
@@ -183,12 +179,7 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
             placeholder=" "
             aria-invalid={ariaInvalid}
             aria-describedby={errorMessage ? errorId : undefined}
-            className={cn(
-              baseInputStyles,
-              label && 'pt-16',
-              suffix && 'pr-8',
-              prefix && 'pl-8',
-            )}
+            className={cn(baseInputStyles, label && 'pt-16')}
             onChange={handleInput}
             {...(({ 'aria-invalid': _, onChange: __, ...rest }) => rest)(props)}
           />
@@ -206,7 +197,7 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
               onClick={() => {
                 handleClear();
               }}
-              className="mr-16 cursor-pointer rounded-full"
+              className="cursor-pointer rounded-full"
               aria-label="Clear input"
               data-side="right"
             >
@@ -214,11 +205,7 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
             </button>
           )}
 
-          {suffix && !showClearButton && (
-            <div className="mr-16" data-side="right">
-              {suffix}
-            </div>
-          )}
+          {suffix && !showClearButton && <div data-side="right">{suffix}</div>}
         </div>
         {errorMessage && (
           <div

--- a/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
+++ b/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
@@ -185,7 +185,12 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
             if (!input) return;
 
             const isSuffix = target.closest('[data-side="right"]');
-            const cursorPosition = isSuffix ? input.value.length : 0;
+            // Smart cursor positioning for better UX:
+            // - Suffix clicks: always end (natural for right-side elements)
+            // - Label/container clicks with content: end (user likely wants to continue typing)
+            // - Label/container clicks on empty input: start (natural starting point)
+            const cursorPosition =
+              isSuffix || input.value.length > 0 ? input.value.length : 0;
 
             window.requestAnimationFrame(() => {
               try {

--- a/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
+++ b/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
@@ -25,7 +25,7 @@ const baseLabelStyles = cn(
 );
 
 export interface BaseInputProps
-  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size' | 'prefix'> {
   /** The label text that floats above the input when focused or filled */
   label?: string;
   /** Additional class names to apply to the input */
@@ -33,15 +33,15 @@ export interface BaseInputProps
   /** An optional error message displayed below the input */
   errorMessage?: string;
   /**
-   * Custom content to render on the right side of the input.
-   * @example rightElement={<Icon />}
+   * Custom content to render after the input (right side in LTR).
+   * @example suffix={<Icon />}
    */
-  rightElement?: React.ReactNode;
+  suffix?: React.ReactNode;
   /**
-   * Custom content to render on the left side of the input.
-   * @example leftElement={<Icon />}
+   * Custom content to render before the input (left side in LTR).
+   * @example prefix={<Icon />}
    */
-  leftElement?: React.ReactNode;
+  prefix?: React.ReactNode;
   /** Optional function to override the default clear behavior */
   onClear?: () => void;
   /** Hide the clear button (shown by default when input has content) */
@@ -64,8 +64,8 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
       id,
       disabled,
       errorMessage,
-      rightElement,
-      leftElement,
+      suffix,
+      prefix,
       onClear,
       hideClearButton = false,
       ...props
@@ -157,8 +157,8 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
             const input = inputRef.current;
             if (!input) return;
 
-            const isRightElement = target.closest('[data-side="right"]');
-            const cursorPosition = isRightElement ? input.value.length : 0;
+            const isSuffix = target.closest('[data-side="right"]');
+            const cursorPosition = isSuffix ? input.value.length : 0;
 
             window.requestAnimationFrame(() => {
               try {
@@ -170,9 +170,9 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
             });
           }}
         >
-          {leftElement && (
+          {prefix && (
             <div data-side="left" className="ml-16">
-              {leftElement}
+              {prefix}
             </div>
           )}
 
@@ -186,8 +186,8 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
             className={cn(
               baseInputStyles,
               label && 'pt-16',
-              rightElement && 'pr-8',
-              leftElement && 'pl-8',
+              suffix && 'pr-8',
+              prefix && 'pl-8',
             )}
             onChange={handleInput}
             {...(({ 'aria-invalid': _, onChange: __, ...rest }) => rest)(props)}
@@ -214,9 +214,9 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
             </button>
           )}
 
-          {rightElement && !showClearButton && (
+          {suffix && !showClearButton && (
             <div className="mr-16" data-side="right">
-              {rightElement}
+              {suffix}
             </div>
           )}
         </div>

--- a/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
+++ b/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
@@ -106,6 +106,12 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
 
     const isControlled = props.value !== undefined;
 
+    // For uncontrolled inputs, we need state to track value changes for UI reactivity.
+    // We can't use inputRef.current.value directly because:
+    // 1. On first render, inputRef.current is null (so we fallback to defaultValue)
+    // 2. When clearing the input, DOM value changes but React doesn't re-render
+    //    to recalculate hasContent, causing clear button to stay visible
+    // This state is only for UI reactivity (clear button visibility), not controlling the input
     const [uncontrolledValue, setUncontrolledValue] = React.useState(
       props.defaultValue?.toString() || '',
     );

--- a/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
+++ b/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { cn } from '@ldls/utils-shared';
+
+const baseInputStyles = cn(
+  'peer block h-48 w-full rounded-md bg-muted px-12 text-base outline-none transition-colors body-2',
+  'hover:bg-muted-hover focus-visible:ring-2 focus-visible:ring-active',
+  'disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-disabled disabled:text-disabled',
+  'aria-[invalid=true]:ring-1 aria-[invalid=true]:ring-error aria-[invalid=true]:border-error',
+);
+
+const baseLabelStyles = cn(
+  'absolute left-12 top-8 origin-left text-muted transition-all duration-300 body-4',
+  'peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:scale-100 peer-placeholder-shown:body-2',
+  'peer-focus:top-8 peer-focus:-translate-y-0 peer-focus:body-4',
+);
+
+export interface BaseInputProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  /** The label text that floats above the input when focused or filled */
+  label?: string;
+  /** Additional class names to apply to the input */
+  className?: string;
+}
+
+/**
+ * Base input component with floating label and error state styling.
+ * This is an internal component used to build other input components.
+ *
+ * @internal
+ */
+export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
+  ({ className, label, id, disabled, ...props }, ref) => {
+    // Generate a unique ID if one isn't provided
+    const inputId = id || `input-${Math.random().toString(36).slice(2, 11)}`;
+
+    return (
+      <div className="relative w-full">
+        <input
+          ref={ref}
+          id={inputId}
+          disabled={disabled}
+          placeholder=" "
+          className={cn(baseInputStyles, label && 'pt-16', className)}
+          {...props}
+        />
+        {label && (
+          <label htmlFor={inputId} className={baseLabelStyles}>
+            {label}
+          </label>
+        )}
+      </div>
+    );
+  },
+);
+
+BaseInput.displayName = 'BaseInput';

--- a/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
+++ b/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
@@ -123,7 +123,7 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
             });
           }}
         >
-          {leftElement && !showClearButton && (
+          {leftElement && (
             <div data-side="left" className="ml-16">
               {leftElement}
             </div>

--- a/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
+++ b/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
@@ -84,6 +84,7 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
 
     const errorId = `${inputId}-error`;
 
+    /** TODO: move to ui-core */
     function composeRefs<T>(...refs: (React.Ref<T> | undefined)[]) {
       return (node: T) => {
         refs.forEach((ref) => {

--- a/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
+++ b/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
@@ -102,7 +102,7 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
     return (
       <div>
         <div
-          className={cn(baseRootStyles, className)}
+          className={cn(className, baseRootStyles)}
           onPointerDown={(event: React.PointerEvent<HTMLDivElement>) => {
             const target = event.target as Element;
             if (target.closest('input, button, a')) return;

--- a/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
+++ b/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
@@ -28,8 +28,12 @@ export interface BaseInputProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size' | 'prefix'> {
   /** The label text that floats above the input when focused or filled */
   label?: string;
-  /** Additional class names to apply to the input */
+  /** Additional class names to apply to the input element */
   className?: string;
+  /** Additional class names to apply to the container element */
+  containerClassName?: string;
+  /** Additional class names to apply to the label element */
+  labelClassName?: string;
   /** An optional error message displayed below the input */
   errorMessage?: string;
   /**
@@ -53,6 +57,11 @@ export interface BaseInputProps
  * Shows a clear button by default when input has content. Use hideClearButton to hide it.
  * This is an internal component used to build other input components.
  *
+ * Supports className customization for different elements:
+ * - `className`: Applied to the input element
+ * - `containerClassName`: Applied to the container/root element
+ * - `labelClassName`: Applied to the floating label element
+ *
  * @internal
  */
 
@@ -60,6 +69,8 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
   (
     {
       className,
+      containerClassName,
+      labelClassName,
       label,
       id,
       disabled,
@@ -149,7 +160,7 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
     return (
       <div>
         <div
-          className={cn(className, baseRootStyles)}
+          className={cn(containerClassName, baseRootStyles)}
           onPointerDown={(event: React.PointerEvent<HTMLDivElement>) => {
             const target = event.target as Element;
             if (target.closest('input, button, a')) return;
@@ -179,13 +190,16 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
             placeholder=" "
             aria-invalid={ariaInvalid}
             aria-describedby={errorMessage ? errorId : undefined}
-            className={cn(baseInputStyles, label && 'pt-16')}
+            className={cn(baseInputStyles, label && 'pt-16', className)}
             onChange={handleInput}
             {...(({ 'aria-invalid': _, onChange: __, ...rest }) => rest)(props)}
           />
 
           {label && (
-            <label htmlFor={inputId} className={baseLabelStyles}>
+            <label
+              htmlFor={inputId}
+              className={cn(baseLabelStyles, labelClassName)}
+            >
               {label}
             </label>
           )}

--- a/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
+++ b/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
@@ -152,6 +152,7 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
           )}
 
           {showClearButton && (
+            /** TODO: extract to a new component IconButton */
             <button
               type="button"
               onClick={onClear}

--- a/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
+++ b/libs/ui-react/src/lib/Components/Input/BaseInput.tsx
@@ -1,16 +1,26 @@
 import React from 'react';
 import { cn } from '@ldls/utils-shared';
+import { DeleteCircleFill } from '../../Symbols';
+
+const baseRootStyles = cn(
+  'group relative flex h-48 w-full items-center rounded-md bg-muted transition-colors',
+  'hover:bg-muted-hover focus-within:ring-2 focus-within:ring-active',
+  'has-[:disabled]:pointer-events-none has-[:disabled]:cursor-not-allowed has-[:disabled]:bg-disabled has-[:disabled]:text-disabled',
+  'has-[:invalid]:ring-1 has-[:invalid]:ring-error has-[:invalid]:border-error',
+  'has-[input[aria-invalid="true"]]:ring-1 has-[input[aria-invalid="true"]]:ring-error has-[input[aria-invalid="true"]]:border-error',
+);
 
 const baseInputStyles = cn(
-  'peer block h-48 w-full rounded-md bg-muted px-12 text-base outline-none transition-colors body-2',
-  'hover:bg-muted-hover focus-visible:ring-2 focus-visible:ring-active',
-  'disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-disabled disabled:text-disabled',
-  'aria-[invalid=true]:ring-1 aria-[invalid=true]:ring-error aria-[invalid=true]:border-error',
+  'peer flex-1 bg-transparent pl-16 text-base outline-none body-2 transition-colors bg-muted rounded-md',
+  'group-hover:bg-muted-hover group-disabled:bg-disabled',
+  'group-has-[:disabled]:pointer-events-none group-has-[:disabled]:cursor-not-allowed group-has-[:disabled]:bg-disabled group-has-[:disabled]:text-disabled',
+  'placeholder:text-transparent',
 );
 
 const baseLabelStyles = cn(
-  'absolute left-12 top-8 origin-left text-muted transition-all duration-300 body-4',
+  'pointer-events-none absolute left-16 top-8 origin-left text-muted transition-all duration-300 body-4',
   'peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:scale-100 peer-placeholder-shown:body-2',
+  'group-has-[:disabled]:text-disabled',
   'peer-focus:top-8 peer-focus:-translate-y-0 peer-focus:body-4',
 );
 
@@ -20,6 +30,20 @@ export interface BaseInputProps
   label?: string;
   /** Additional class names to apply to the input */
   className?: string;
+  /** An optional error message displayed below the input */
+  errorMessage?: string;
+  /**
+   * Custom content to render on the right side of the input.
+   * @example rightElement={<Icon />}
+   */
+  rightElement?: React.ReactNode;
+  /**
+   * Custom content to render on the left side of the input.
+   * @example leftElement={<Icon />}
+   */
+  leftElement?: React.ReactNode;
+  /** Function to clear the input via a clear button */
+  onClear?: () => void;
 }
 
 /**
@@ -28,25 +52,133 @@ export interface BaseInputProps
  *
  * @internal
  */
+
 export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
-  ({ className, label, id, disabled, ...props }, ref) => {
-    // Generate a unique ID if one isn't provided
+  (
+    {
+      className,
+      label,
+      id,
+      disabled,
+      errorMessage,
+      rightElement,
+      leftElement,
+      onClear,
+      ...props
+    },
+    ref,
+  ) => {
+    const inputRef = React.useRef<HTMLInputElement>(null);
+
     const inputId = id || `input-${Math.random().toString(36).slice(2, 11)}`;
 
+    // Handle aria-invalid properly - use provided value or derive from errorMessage
+    const ariaInvalid = props['aria-invalid']
+      ? props['aria-invalid']
+      : errorMessage
+        ? true
+        : undefined;
+
+    const hasContent = !!props.value && props.value.toString().length > 0;
+    const showClearButton = hasContent && !disabled && onClear;
+
+    const errorId = `${inputId}-error`;
+
+    function composeRefs<T>(...refs: (React.Ref<T> | undefined)[]) {
+      return (node: T) => {
+        refs.forEach((ref) => {
+          if (!ref) return;
+          if (typeof ref === 'function') {
+            ref(node);
+          } else {
+            (ref as React.MutableRefObject<T | null>).current = node;
+          }
+        });
+      };
+    }
+
     return (
-      <div className="relative w-full">
-        <input
-          ref={ref}
-          id={inputId}
-          disabled={disabled}
-          placeholder=" "
-          className={cn(baseInputStyles, label && 'pt-16', className)}
-          {...props}
-        />
-        {label && (
-          <label htmlFor={inputId} className={baseLabelStyles}>
-            {label}
-          </label>
+      <div>
+        <div
+          className={cn(baseRootStyles, className)}
+          onPointerDown={(event: React.PointerEvent<HTMLDivElement>) => {
+            const target = event.target as Element;
+            if (target.closest('input, button, a')) return;
+
+            const input = inputRef.current;
+            if (!input) return;
+
+            const isRightElement = target.closest('[data-side="right"]');
+            const cursorPosition = isRightElement ? input.value.length : 0;
+
+            window.requestAnimationFrame(() => {
+              try {
+                input.setSelectionRange(cursorPosition, cursorPosition);
+              } catch {
+                // setSelectionRange is not supported on all input types
+              }
+              input.focus();
+            });
+          }}
+        >
+          {leftElement && !showClearButton && (
+            <div data-side="left" className="ml-16">
+              {leftElement}
+            </div>
+          )}
+
+          <input
+            ref={composeRefs(ref, inputRef)}
+            id={inputId}
+            disabled={disabled}
+            placeholder=" "
+            aria-invalid={ariaInvalid}
+            aria-describedby={errorMessage ? errorId : undefined}
+            className={cn(
+              baseInputStyles,
+              label && 'pt-16',
+              rightElement && 'pr-8',
+              leftElement && 'pl-8',
+            )}
+            {...(({ 'aria-invalid': _, ...rest }) => rest)(props)}
+          />
+
+          {label && (
+            <label htmlFor={inputId} className={baseLabelStyles}>
+              {label}
+            </label>
+          )}
+
+          {showClearButton && (
+            <button
+              type="button"
+              onClick={onClear}
+              className="mr-16 cursor-pointer rounded-full"
+              aria-label="Clear input"
+              data-side="right"
+            >
+              <DeleteCircleFill
+                size={20}
+                className={cn('text-muted', ariaInvalid && 'text-error')}
+              />
+            </button>
+          )}
+
+          {rightElement && !showClearButton && (
+            <div className="mr-16" data-side="right">
+              {rightElement}
+            </div>
+          )}
+        </div>
+        {errorMessage && (
+          <div
+            id={errorId}
+            className="mt-8 flex items-center gap-2 text-error body-3"
+            role="alert"
+          >
+            <DeleteCircleFill size={16} className="flex-shrink-0 text-error" />
+            <span>{errorMessage}</span>
+          </div>
         )}
       </div>
     );

--- a/libs/ui-react/src/lib/Components/Input/Input.implementation.mdx
+++ b/libs/ui-react/src/lib/Components/Input/Input.implementation.mdx
@@ -1,0 +1,278 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Components/Input/Implementation" />
+
+# Input Component Implementation
+
+## Installation
+
+First, ensure you are connected to the VPN, login to the npm registry and create a `.npmrc` file in your project root:
+
+```bash
+npm login --registry=https://jfrog.ledgerlabs.net/artifactory/api/npm/ldls-npm-prod-public/
+```
+
+```bash
+# .npmrc
+@ldls:registry=https://jfrog.ledgerlabs.net/artifactory/api/npm/ldls-npm-prod-public/
+```
+
+Then install the packages and their peer dependencies:
+
+```bash
+# Install the UI Kit
+npm install @ldls/ui-react @ldls/design-core
+
+# Install peer dependencies
+npm install tailwindcss@^3.4.0 react@^18.3.1 clsx tailwind-merge
+```
+
+### Tailwind Configuration
+
+To use the Input component with our custom Tailwind preset, you need to configure your `tailwind.config.ts`:
+
+```typescript
+import type { Config } from 'tailwindcss';
+import { ledgerLivePreset } from '@ldls/design-core';
+
+const config = {
+  content: [
+    "./src/**/*.{js,ts,jsx,tsx}", // Your project's files
+    "./node_modules/@ldls/ui-react/dist/lib/**/*.{js,ts,jsx,tsx}" // Ledger UI Kit components
+  ],
+  presets: [ledgerLivePreset], // the installed tailwind preset
+} satisfies Config;
+
+export default config;
+```
+
+### Basic Usage
+
+```tsx
+import { Input } from '@ldls/ui-react';
+
+function MyComponent() {
+  const [value, setValue] = React.useState('');
+
+  return (
+    <Input
+      label="Username"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    />
+  );
+}
+```
+
+### With Clear Button
+
+The Input component supports a clear button that appears when content is present:
+
+```tsx
+import { Input } from '@ldls/ui-react';
+
+function MyComponent() {
+  const [value, setValue] = React.useState('');
+
+  return (
+    <Input
+      label="Search"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      onClear={() => setValue('')}
+    />
+  );
+}
+```
+
+### With Custom Right Element
+
+You can add custom elements to the right side of the input. Define reusable components for better organization and performance:
+
+```tsx
+import { Input } from '@ldls/ui-react';
+import { InformationFill, SparksFill } from '@ldls/ui-react/symbols';
+
+
+// Action button component
+const GeneratePasswordButton = () => (
+  <button
+    type="button"
+    onClick={() => alert('Generate password')}
+    className="rounded-full p-2 transition-colors hover:bg-muted-hover"
+    aria-label="Generate random password"
+  >
+    <SparksFill size={20} className="text-muted" />
+  </button>
+);
+
+function MyComponent() {
+  const [value, setValue] = React.useState('');
+
+  return (
+    <div className="space-y-16">
+      <Input
+        label="Password"
+        type="password"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        renderRightElement={GeneratePasswordButton}
+      />
+    </div>
+  );
+}
+```
+
+### With Error State
+
+The Input component supports error states and messages:
+
+```tsx
+import { Input } from '@ldls/ui-react';
+
+function MyComponent() {
+  const [value, setValue] = React.useState('');
+  const [error, setError] = React.useState(false);
+
+  const handleChange = (e) => {
+    const newValue = e.target.value;
+    setValue(newValue);
+    setError(newValue.length < 3);
+  };
+
+  return (
+    <Input
+      label="Username"
+      value={value}
+      onChange={handleChange}
+      aria-invalid={error}
+      errorMessage={error ? 'Must be at least 3 characters' : undefined}
+    />
+  );
+}
+```
+
+## Do's and Don'ts
+
+### Value Management
+
+✅ **Do**
+
+```tsx
+// Use controlled input pattern
+const [value, setValue] = useState('');
+<Input
+  value={value}
+  onChange={(e) => setValue(e.target.value)}
+/>
+
+// Use onClear for clear button functionality
+<Input
+  value={value}
+  onChange={handleChange}
+  onClear={() => setValue('')}
+/>
+
+// Use aria-invalid for error states
+<Input
+  value={value}
+  onChange={handleChange}
+  aria-invalid={hasError}
+  errorMessage={hasError ? 'Invalid input' : undefined}
+/>
+```
+
+❌ **Don't**
+
+```tsx
+// Don't use uncontrolled inputs
+<Input defaultValue="initial" />
+
+// Don't handle clear button manually
+<Input
+  value={value}
+  onChange={handleChange}
+  renderRightElement={() => (
+    <button onClick={() => setValue('')}>Clear</button>
+  )}
+/>
+
+// Don't use custom error props
+<Input error={true} errorText="Invalid input" />
+```
+
+### Layout and Styling
+
+✅ **Do**
+
+```tsx
+// Use className for layout positioning
+<Input className="mt-4" />
+
+// Use className for width control
+<Input className="w-64" />
+
+// Use className for responsive design
+<Input className="w-full md:w-64" />
+```
+
+❌ **Don't**
+
+```tsx
+// Don't override core input styling
+<Input className="bg-white border-gray-300" />
+
+// Don't modify internal padding/spacing
+<Input className="px-6 py-4" />
+
+// Don't override typography
+<Input className="text-lg" />
+
+// Don't modify hover/focus states
+<Input className="hover:border-blue-500" />
+```
+
+### Performance Considerations
+
+✅ **Do**
+
+```tsx
+// Import specific icons
+import { InformationFill } from '@ldls/ui-react/symbols';
+
+// Memoize complex right elements
+const InfoButton = React.memo(() => (
+  <button
+    type="button"
+    aria-label="Show information"
+    className="rounded-full p-2 hover:bg-muted-hover"
+  >
+    <InformationFill size={20} className="text-muted" />
+  </button>
+));
+
+<Input renderRightElement={InfoButton} />
+
+// Use stable callbacks
+const handleClear = useCallback(() => setValue(''), [setValue]);
+<Input onClear={handleClear} />
+```
+
+❌ **Don't**
+
+```tsx
+// Don't import all icons
+import * as Icons from '@ldls/ui-react/symbols';
+
+// Don't create new functions in render
+<Input onClear={() => setValue('')} />
+
+// Don't create complex elements inline
+<Input
+  renderRightElement={() => (
+    <ComplexComponent>
+      <NestedComponents />
+    </ComplexComponent>
+  )}
+/>
+```

--- a/libs/ui-react/src/lib/Components/Input/Input.implementation.mdx
+++ b/libs/ui-react/src/lib/Components/Input/Input.implementation.mdx
@@ -64,9 +64,11 @@ function MyComponent() {
 }
 ```
 
-### With Clear Button
+> **Note:** Clear button appears automatically when input has content. Use `hideClearButton` to hide it.
 
-The Input component automatically shows a clear button when content is present:
+#### **Hiding the Clear Button**
+
+Use `hideClearButton` to prevent the clear button from appearing:
 
 ```tsx
 import { Input } from '@ldls/ui-react';
@@ -76,15 +78,16 @@ function MyComponent() {
 
   return (
     <Input
-      label="Search"
+      label="Username"
       value={value}
       onChange={(e) => setValue(e.target.value)}
+      hideClearButton // Clear button will not appear
     />
   );
 }
 ```
 
-#### Custom Clear Behavior
+#### **Extending the Clear Behavior**
 
 Provide `onClear` to extend the default clear behavior with additional logic:
 
@@ -104,27 +107,6 @@ function MyComponent() {
         // Add your custom logic here
         analytics.track('search_cleared');
       }}
-    />
-  );
-}
-```
-
-#### Hiding the Clear Button
-
-Use `hideClearButton` to prevent the clear button from appearing:
-
-```tsx
-import { Input } from '@ldls/ui-react';
-
-function MyComponent() {
-  const [value, setValue] = React.useState('');
-
-  return (
-    <Input
-      label="Username"
-      value={value}
-      onChange={(e) => setValue(e.target.value)}
-      hideClearButton // Clear button will not appear
     />
   );
 }
@@ -198,6 +180,8 @@ function MyComponent() {
   );
 }
 ```
+
+> **Note:** Error message are optional. Use `errorMessage` to display an error message below the input.
 
 ## ⚠️ Label vs Placeholder
 

--- a/libs/ui-react/src/lib/Components/Input/Input.implementation.mdx
+++ b/libs/ui-react/src/lib/Components/Input/Input.implementation.mdx
@@ -66,7 +66,7 @@ function MyComponent() {
 
 ### With Clear Button
 
-The Input component supports a clear button that appears when content is present:
+The Input component supports a clear button that appears when content is present and onClear is provided:
 
 ```tsx
 import { Input } from '@ldls/ui-react';
@@ -87,19 +87,19 @@ function MyComponent() {
 
 ### With Custom Right Element
 
-You can add custom elements to the right side of the input. Define reusable components for better organization and performance:
+You can add custom elements to the right side of the input.
+
+> **Note:** Define reusable components for better organization and performance:
 
 ```tsx
 import { Input } from '@ldls/ui-react';
 import { InformationFill, SparksFill } from '@ldls/ui-react/symbols';
-
 
 // Action button component
 const GeneratePasswordButton = () => (
   <button
     type="button"
     onClick={() => alert('Generate password')}
-    className="rounded-full p-2 transition-colors hover:bg-muted-hover"
     aria-label="Generate random password"
   >
     <SparksFill size={20} className="text-muted" />
@@ -116,12 +116,14 @@ function MyComponent() {
         type="password"
         value={value}
         onChange={(e) => setValue(e.target.value)}
-        renderRightElement={GeneratePasswordButton}
+        rightElement={<GeneratePasswordButton />}
       />
     </div>
   );
 }
 ```
+
+> ⚠️ **Important:** If you provide both `rightElement` and `onClear`, the clear button will take priority and replace your custom element when the input has content! 🔄
 
 ### With Error State
 
@@ -152,7 +154,45 @@ function MyComponent() {
 }
 ```
 
+## ⚠️ Label vs Placeholder
+
+**Important:** Do not combine `label` and `placeholder` props together. They will visually overlap and create a poor user experience.
+
+The Input component uses floating labels that animate from inside the input field. Using both simultaneously causes visual conflicts.
+
+### ✅ Correct Usage
+
+```tsx
+// Use floating label (recommended approach)
+<Input
+  label="Email Address"
+  value={email}
+  onChange={(e) => setEmail(e.target.value)}
+/>
+
+// OR use placeholder (alternative approach)
+<Input
+  placeholder="Enter your email address"
+  value={email}
+  onChange={(e) => setEmail(e.target.value)}
+/>
+```
+
+### ❌ Incorrect Usage
+
+```tsx
+// DON'T DO THIS - causes visual overlap
+<Input
+  label="Email Address"
+  placeholder="Enter your email address"  // This will overlap with the label
+  value={email}
+  onChange={(e) => setEmail(e.target.value)}
+/>
+```
+
 ## Do's and Don'ts
+
+With Custom Right Element
 
 ### Value Management
 
@@ -192,9 +232,9 @@ const [value, setValue] = useState('');
 <Input
   value={value}
   onChange={handleChange}
-  renderRightElement={() => (
-    <button onClick={() => setValue('')}>Clear</button>
-  )}
+  rightElement={
+    <Button onClick={() => setValue('')}>Clear</Button>
+  }
 />
 
 // Don't use custom error props
@@ -251,7 +291,7 @@ const InfoButton = React.memo(() => (
   </button>
 ));
 
-<Input renderRightElement={InfoButton} />
+<Input rightElement={<InfoButton />} />
 
 // Use stable callbacks
 const handleClear = useCallback(() => setValue(''), [setValue]);
@@ -269,10 +309,10 @@ import * as Icons from '@ldls/ui-react/symbols';
 
 // Don't create complex elements inline
 <Input
-  renderRightElement={() => (
+  rightElement={
     <ComplexComponent>
       <NestedComponents />
     </ComplexComponent>
-  )}
+  }
 />
 ```

--- a/libs/ui-react/src/lib/Components/Input/Input.implementation.mdx
+++ b/libs/ui-react/src/lib/Components/Input/Input.implementation.mdx
@@ -161,14 +161,14 @@ function MyComponent() {
         type="password"
         value={value}
         onChange={(e) => setValue(e.target.value)}
-        rightElement={<GeneratePasswordButton />}
+        suffix={<GeneratePasswordButton />}
       />
     </div>
   );
 }
 ```
 
-> ⚠️ **Important:** The clear button appears automatically when input has content and will take priority over your `rightElement`. Use `hideClearButton={true}` if you need persistent right-side content! 🔄
+> ⚠️ **Important:** The clear button appears automatically when input has content and will take priority over your `suffix`. Use `hideClearButton={true}` if you need persistent right-side content! 🔄
 
 ### With Error State
 
@@ -293,7 +293,7 @@ const [value, setValue] = useState('');
 <Input
   value={value}
   onChange={handleChange}
-  rightElement={
+  suffix={
     <Button onClick={() => setValue('')}>Clear</Button>
   }
 />
@@ -359,7 +359,7 @@ const InfoButton = React.memo(() => (
   </button>
 ));
 
-<Input rightElement={<InfoButton />} />
+<Input suffix={<InfoButton />} />
 
 // Use stable callbacks only for custom clear behavior
 const handleCustomClear = useCallback(() => {
@@ -383,7 +383,7 @@ import * as Icons from '@ldls/ui-react/symbols';
 
 // Don't create complex elements inline
 <Input
-  rightElement={
+  suffix={
     <ComplexComponent>
       <NestedComponents />
     </ComplexComponent>

--- a/libs/ui-react/src/lib/Components/Input/Input.implementation.mdx
+++ b/libs/ui-react/src/lib/Components/Input/Input.implementation.mdx
@@ -66,7 +66,7 @@ function MyComponent() {
 
 ### With Clear Button
 
-The Input component supports a clear button that appears when content is present and onClear is provided:
+The Input component automatically shows a clear button when content is present:
 
 ```tsx
 import { Input } from '@ldls/ui-react';
@@ -79,7 +79,52 @@ function MyComponent() {
       label="Search"
       value={value}
       onChange={(e) => setValue(e.target.value)}
-      onClear={() => setValue('')}
+    />
+  );
+}
+```
+
+#### Custom Clear Behavior
+
+Provide `onClear` to override the default clear behavior:
+
+```tsx
+import { Input } from '@ldls/ui-react';
+
+function MyComponent() {
+  const [value, setValue] = React.useState('');
+
+  return (
+    <Input
+      label="Search"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      onClear={() => {
+        setValue('');
+        // Additional custom logic
+        analytics.track('search_cleared');
+      }}
+    />
+  );
+}
+```
+
+#### Hiding the Clear Button
+
+Use `hideClearButton` to prevent the clear button from appearing:
+
+```tsx
+import { Input } from '@ldls/ui-react';
+
+function MyComponent() {
+  const [value, setValue] = React.useState('');
+
+  return (
+    <Input
+      label="Username"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      hideClearButton // Clear button will not appear
     />
   );
 }
@@ -123,7 +168,7 @@ function MyComponent() {
 }
 ```
 
-> ⚠️ **Important:** If you provide both `rightElement` and `onClear`, the clear button will take priority and replace your custom element when the input has content! 🔄
+> ⚠️ **Important:** The clear button appears automatically when input has content and will take priority over your `rightElement`. Use `hideClearButton={true}` if you need persistent right-side content! 🔄
 
 ### With Error State
 
@@ -206,11 +251,27 @@ const [value, setValue] = useState('');
   onChange={(e) => setValue(e.target.value)}
 />
 
-// Use onClear for clear button functionality
+// Clear button appears automatically - hideClearButton is false by default
 <Input
   value={value}
   onChange={handleChange}
-  onClear={() => setValue('')}
+/>
+
+// Use onClear only for custom clear behavior
+<Input
+  value={value}
+  onChange={handleChange}
+  onClear={() => {
+    setValue('');
+    customClearLogic();
+  }}
+/>
+
+// Hide clear button when needed
+<Input
+  value={value}
+  onChange={handleChange}
+  hideClearButton
 />
 
 // Use aria-invalid for error states
@@ -228,13 +289,20 @@ const [value, setValue] = useState('');
 // Don't use uncontrolled inputs
 <Input defaultValue="initial" />
 
-// Don't handle clear button manually
+// Don't create custom clear buttons - use the built-in one
 <Input
   value={value}
   onChange={handleChange}
   rightElement={
     <Button onClick={() => setValue('')}>Clear</Button>
   }
+/>
+
+// Don't provide onClear just to clear the value
+<Input
+  value={value}
+  onChange={handleChange}
+  onClear={() => setValue('')} // Unnecessary - this is default behavior
 />
 
 // Don't use custom error props
@@ -293,9 +361,12 @@ const InfoButton = React.memo(() => (
 
 <Input rightElement={<InfoButton />} />
 
-// Use stable callbacks
-const handleClear = useCallback(() => setValue(''), [setValue]);
-<Input onClear={handleClear} />
+// Use stable callbacks only for custom clear behavior
+const handleCustomClear = useCallback(() => {
+  setValue('');
+  customClearLogic();
+}, [setValue]);
+<Input onClear={handleCustomClear} />
 ```
 
 ❌ **Don't**
@@ -304,8 +375,11 @@ const handleClear = useCallback(() => setValue(''), [setValue]);
 // Don't import all icons
 import * as Icons from '@ldls/ui-react/symbols';
 
-// Don't create new functions in render
-<Input onClear={() => setValue('')} />
+// Don't provide onClear for basic clearing (it's automatic now)
+<Input onClear={() => setValue('')} /> // Unnecessary
+
+// Don't create new functions in render for custom behavior
+<Input onClear={() => { setValue(''); customLogic(); }} />
 
 // Don't create complex elements inline
 <Input

--- a/libs/ui-react/src/lib/Components/Input/Input.implementation.mdx
+++ b/libs/ui-react/src/lib/Components/Input/Input.implementation.mdx
@@ -86,7 +86,7 @@ function MyComponent() {
 
 #### Custom Clear Behavior
 
-Provide `onClear` to override the default clear behavior:
+Provide `onClear` to extend the default clear behavior with additional logic:
 
 ```tsx
 import { Input } from '@ldls/ui-react';
@@ -100,8 +100,8 @@ function MyComponent() {
       value={value}
       onChange={(e) => setValue(e.target.value)}
       onClear={() => {
-        setValue('');
-        // Additional custom logic
+        // Default clearing happens automatically
+        // Add your custom logic here
         analytics.track('search_cleared');
       }}
     />
@@ -251,18 +251,25 @@ const [value, setValue] = useState('');
   onChange={(e) => setValue(e.target.value)}
 />
 
+// Or use uncontrolled inputs (also valid)
+<Input defaultValue="initial value" />
+
+// Uncontrolled with ref access
+const inputRef = useRef<HTMLInputElement>(null);
+<Input ref={inputRef} defaultValue="" />
+
 // Clear button appears automatically - hideClearButton is false by default
 <Input
   value={value}
   onChange={handleChange}
 />
 
-// Use onClear only for custom clear behavior
+// Use onClear to extend default clear behavior with custom logic
 <Input
   value={value}
   onChange={handleChange}
   onClear={() => {
-    setValue('');
+    // Default clearing happens automatically
     customClearLogic();
   }}
 />
@@ -286,26 +293,24 @@ const [value, setValue] = useState('');
 ❌ **Don't**
 
 ```tsx
-// Don't use uncontrolled inputs
-<Input defaultValue="initial" />
-
 // Don't create custom clear buttons - use the built-in one
+
 <Input
   value={value}
   onChange={handleChange}
-  suffix={
-    <Button onClick={() => setValue('')}>Clear</Button>
-  }
+  suffix={<Button onClick={() => setValue('')}>Clear</Button>}
 />
 
-// Don't provide onClear just to clear the value
+// Don't manually clear the value in onClear - it happens automatically
+
 <Input
   value={value}
   onChange={handleChange}
-  onClear={() => setValue('')} // Unnecessary - this is default behavior
+  onClear={() => setValue('')} // Redundant - clearing happens by default
 />
 
 // Don't use custom error props
+
 <Input error={true} errorText="Invalid input" />
 ```
 
@@ -361,11 +366,11 @@ const InfoButton = React.memo(() => (
 
 <Input suffix={<InfoButton />} />
 
-// Use stable callbacks only for custom clear behavior
+// Use stable callbacks for extending clear behavior
 const handleCustomClear = useCallback(() => {
-  setValue('');
+  // Default clearing happens automatically
   customClearLogic();
-}, [setValue]);
+}, []);
 <Input onClear={handleCustomClear} />
 ```
 
@@ -375,11 +380,11 @@ const handleCustomClear = useCallback(() => {
 // Don't import all icons
 import * as Icons from '@ldls/ui-react/symbols';
 
-// Don't provide onClear for basic clearing (it's automatic now)
-<Input onClear={() => setValue('')} /> // Unnecessary
+// Don't manually clear in onClear - it's automatic
+<Input onClear={() => setValue('')} /> // Redundant
 
-// Don't create new functions in render for custom behavior
-<Input onClear={() => { setValue(''); customLogic(); }} />
+// Don't create new functions in render for extending behavior
+<Input onClear={() => { customLogic(); }} /> // Use useCallback instead
 
 // Don't create complex elements inline
 <Input

--- a/libs/ui-react/src/lib/Components/Input/Input.mdx
+++ b/libs/ui-react/src/lib/Components/Input/Input.mdx
@@ -55,13 +55,13 @@ The input supports error handling through:
 
 ### Custom Right Element
 
-The input supports custom interactive elements on the right side through the `rightElement` prop:
+The input supports custom interactive elements on the right side through the `suffix` prop:
 
 <Canvas of={InputStories.WithCustomElement} />
 
 You can add: Tooltips, Action buttons, Custom icons, Any interactive element
 
-> **Important note:** The clear button automatically appears when input has content and will take priority over your `rightElement`. Use `hideClearButton` to prevent this if you need persistent right-side content.
+> **Important note:** The clear button automatically appears when input has content and will take priority over your `suffix`. Use `hideClearButton` to prevent this if you need persistent right-side content.
 
 ### Interactive in a Form
 

--- a/libs/ui-react/src/lib/Components/Input/Input.mdx
+++ b/libs/ui-react/src/lib/Components/Input/Input.mdx
@@ -1,0 +1,149 @@
+import { Meta, Story, Canvas, Controls } from '@storybook/addon-docs/blocks';
+import * as InputStories from './Input.stories';
+import { Input } from './Input';
+
+<Meta title="Components/Input/Docs" of={InputStories} />
+
+# ⌨️ Input
+
+## Introduction
+
+Input fields are essential form elements that enable users to enter and edit text. This component features a floating label, error states, and a clear button for enhanced user experience.
+It also provides the ability to add custom elements on the right side of the input.
+
+> View in [Figma](https://www.figma.com/design/JxaLVMTWirCpU0rsbZ30k7/2.-Components-Library?node-id=6375-6974&m=dev).
+
+## Anatomy
+
+<Canvas of={InputStories.Default} />
+<Controls of={InputStories.Default} />
+
+### Clear Button
+
+A clear button (×) appears when:
+
+- **onClear** is provided
+- Input has content
+
+<Canvas of={InputStories.WithContent} />
+
+### Error State
+
+The input supports error handling through:
+
+- `aria-invalid`: Controls the error state styling
+- `errorMessage`: Displays an error message below the input
+- Error styling includes a red ring and text color
+- Clear button turns red when in error state -- appears when onClear is provided
+
+<Canvas of={InputStories.WithError} />
+
+### Custom Right Element
+
+The input supports custom interactive elements on the right side through the `renderRightElement` prop:
+
+<Canvas of={InputStories.WithCustomElement} />
+
+You can add: Tooltips, Action buttons, Custom icons, Any interactive element
+
+Example with reusable component:
+
+```tsx
+
+const GeneratePasswordButton = () => (
+  <button
+    type="button"
+    onClick={() => alert('Generate password')}
+    className="rounded-full p-2 transition-colors hover:bg-muted-hover"
+    aria-label="Generate random password"
+  >
+    <SparksFill size={20} className="text-muted" />
+  </button>
+);
+
+<Input
+  label="Password"
+  type="password"
+  renderRightElement={GeneratePasswordButton}
+/>
+```
+
+### States
+
+<Canvas of={InputStories.Interactive} />
+
+## Input Types
+
+The component supports various HTML input types:
+
+- text (default)
+- email
+- password
+- number
+- tel
+- url
+
+<Canvas of={InputStories.EmailType} />
+<Canvas of={InputStories.PasswordType} />
+
+## Accessibility
+
+The Input component follows accessibility best practices:
+
+- Uses semantic HTML with proper ARIA attributes
+- Supports keyboard navigation
+- Labels are properly associated with inputs using htmlFor
+- Error messages are linked to inputs using aria-describedby
+- Clear button has an accessible label
+- Error states are communicated through aria-invalid
+
+### Error Message Pattern
+
+```tsx
+<Input
+  id="email"
+  label="Email"
+  aria-invalid={!isValid}
+  errorMessage={!isValid ? "Please enter a valid email" : undefined}
+/>
+```
+
+The error message will be automatically:
+
+- Connected to the input using aria-describedby
+- Displayed with a warning icon
+- Styled in the error color
+- Announced by screen readers
+
+## Controlled vs Uncontrolled
+
+The Input component supports both controlled and uncontrolled usage:
+
+### Uncontrolled (with defaultValue)
+
+```tsx
+<Input
+  label="Username"
+  defaultValue="Initial value"
+/>
+```
+
+### Controlled (with value and onChange)
+
+```tsx
+const [value, setValue] = useState('');
+
+<Input
+  label="Username"
+  value={value}
+  onChange={(e) => setValue(e.target.value)}
+/>
+```
+
+## Best Practices
+
+1. **Labels**: Always provide clear, descriptive labels
+2. **Error Messages**: Make error messages helpful and actionable
+3. **Validation**: Validate on blur or submit, not on every keystroke
+4. **Clear Button**: Use for optional fields where clearing is helpful
+5. **Types**: Use the appropriate input type for the data being collected

--- a/libs/ui-react/src/lib/Components/Input/Input.mdx
+++ b/libs/ui-react/src/lib/Components/Input/Input.mdx
@@ -30,17 +30,23 @@ The clear button provides default functionality for both controlled and uncontro
 
 <Canvas of={InputStories.WithContent} />
 
-#### Default Clear Behavior
+#### **Default Clear Behavior**
 
 The clear button works automatically without requiring an `onClear` prop:
 
 <Canvas of={InputStories.DefaultClearBehavior} />
 
-#### Hiding the Clear Button
+#### **Hiding the Clear Button**
 
 Use `hideClearButton` to prevent the clear button from appearing:
 
 <Canvas of={InputStories.HiddenClearButton} />
+
+#### **Extending the Clear Behavior**
+
+Use `onClear` to extend the default clear behavior with custom logic:
+
+<Canvas of={InputStories.ExtendedClearBehavior} />
 
 ### Error State
 
@@ -49,9 +55,15 @@ The input supports error handling through:
 - `aria-invalid`: Controls the error state styling
 - `errorMessage`: Displays an error message below the input
 - Error styling includes a red ring and text color
-- Clear button turns red when in error state and appears automatically
 
 <Canvas of={InputStories.WithError} />
+
+The error message will be automatically:
+
+- Connected to the input using aria-describedby
+- Displayed with a warning icon
+- Styled in the error color
+- Announced by screen readers
 
 ### Custom Right Element
 
@@ -92,86 +104,23 @@ The Input component follows accessibility best practices:
 - Clear button has an accessible label
 - Error states are communicated through aria-invalid
 
-### Error Message Pattern
-
-```tsx
-<Input
-  id="email"
-  label="Email"
-  aria-invalid={!isValid}
-  errorMessage={!isValid ? "Please enter a valid email" : undefined}
-/>
-```
-
-The error message will be automatically:
-
-- Connected to the input using aria-describedby
-- Displayed with a warning icon
-- Styled in the error color
-- Announced by screen readers
-
 ## Controlled vs Uncontrolled
 
 The Input component supports both controlled and uncontrolled usage:
 
 ### Uncontrolled (with defaultValue)
 
-```tsx
-<Input
-  label="Username"
-  defaultValue="Initial value"
-/>
-```
+<Canvas of={InputStories.UncontrolledInputExample} />
 
 ### Controlled (with value and onChange)
 
-```tsx
-const [value, setValue] = useState('');
-
-<Input
-  label="Username"
-  value={value}
-  onChange={(e) => setValue(e.target.value)}
-/>
-```
+<Canvas of={InputStories.ControlledInputExample} />
 
 ## Label vs Placeholder
 
 > ⚠️ **Important:** Do not combine `label` and `placeholder` props together. They will visually overlap and create a poor user experience.
 
 The Input component uses **floating labels** that animate from inside the input field. Using both label and placeholder simultaneously will cause them to overlap and interfere with each other.
-
-### ✅ Use Label (Recommended)
-
-```tsx
-<Input
-  label="Email Address"
-  value={email}
-  onChange={(e) => setEmail(e.target.value)}
-/>
-```
-
-### ✅ Use Placeholder (Alternative)
-
-```tsx
-<Input
-  placeholder="Enter your email address"
-  value={email}
-  onChange={(e) => setEmail(e.target.value)}
-/>
-```
-
-### ❌ Don't Combine Both
-
-```tsx
-{/* This will cause visual overlap - DON'T DO THIS */}
-<Input
-  label="Email Address"
-  placeholder="Enter your email address"
-  value={email}
-  onChange={(e) => setEmail(e.target.value)}
-/>
-```
 
 ## Best Practices
 

--- a/libs/ui-react/src/lib/Components/Input/Input.mdx
+++ b/libs/ui-react/src/lib/Components/Input/Input.mdx
@@ -8,7 +8,7 @@ import { Input } from './Input';
 
 ## Introduction
 
-Input fields are essential form elements that enable users to enter and edit text. This component features a floating label, error states, and a clear button for enhanced user experience.
+Input fields are essential form elements that enable users to enter and edit text. This component features a floating label, error states, and an automatic clear button for enhanced user experience.
 It also provides the ability to add custom elements on the right side of the input.
 
 > View in [Figma](https://www.figma.com/design/JxaLVMTWirCpU0rsbZ30k7/2.-Components-Library?node-id=6375-6974&m=dev).
@@ -20,12 +20,27 @@ It also provides the ability to add custom elements on the right side of the inp
 
 ### Clear Button
 
-A clear button (×) appears when:
+A clear button (×) appears **automatically** when:
 
-- **onClear** is provided
 - Input has content
+- Input is not disabled
+- `hideClearButton` is not set to `true`
+
+The clear button provides default functionality for both controlled and uncontrolled inputs. You can override this behavior by providing a custom `onClear` function.
 
 <Canvas of={InputStories.WithContent} />
+
+#### Default Clear Behavior
+
+The clear button works automatically without requiring an `onClear` prop:
+
+<Canvas of={InputStories.DefaultClearBehavior} />
+
+#### Hiding the Clear Button
+
+Use `hideClearButton` to prevent the clear button from appearing:
+
+<Canvas of={InputStories.HiddenClearButton} />
 
 ### Error State
 
@@ -34,7 +49,7 @@ The input supports error handling through:
 - `aria-invalid`: Controls the error state styling
 - `errorMessage`: Displays an error message below the input
 - Error styling includes a red ring and text color
-- Clear button turns red when in error state -- appears when onClear is provided
+- Clear button turns red when in error state and appears automatically
 
 <Canvas of={InputStories.WithError} />
 
@@ -46,7 +61,7 @@ The input supports custom interactive elements on the right side through the `ri
 
 You can add: Tooltips, Action buttons, Custom icons, Any interactive element
 
-> **Important note:** if onClear is provided, the clear button will take over your right element once user starts typing.
+> **Important note:** The clear button automatically appears when input has content and will take priority over your `rightElement`. Use `hideClearButton` to prevent this if you need persistent right-side content.
 
 ### Interactive in a Form
 

--- a/libs/ui-react/src/lib/Components/Input/Input.mdx
+++ b/libs/ui-react/src/lib/Components/Input/Input.mdx
@@ -40,35 +40,15 @@ The input supports error handling through:
 
 ### Custom Right Element
 
-The input supports custom interactive elements on the right side through the `renderRightElement` prop:
+The input supports custom interactive elements on the right side through the `rightElement` prop:
 
 <Canvas of={InputStories.WithCustomElement} />
 
 You can add: Tooltips, Action buttons, Custom icons, Any interactive element
 
-Example with reusable component:
+> **Important note:** if onClear is provided, the clear button will take over your right element once user starts typing.
 
-```tsx
-
-const GeneratePasswordButton = () => (
-  <button
-    type="button"
-    onClick={() => alert('Generate password')}
-    className="rounded-full p-2 transition-colors hover:bg-muted-hover"
-    aria-label="Generate random password"
-  >
-    <SparksFill size={20} className="text-muted" />
-  </button>
-);
-
-<Input
-  label="Password"
-  type="password"
-  renderRightElement={GeneratePasswordButton}
-/>
-```
-
-### States
+### Interactive in a Form
 
 <Canvas of={InputStories.Interactive} />
 
@@ -140,10 +120,54 @@ const [value, setValue] = useState('');
 />
 ```
 
+## Label vs Placeholder
+
+> ⚠️ **Important:** Do not combine `label` and `placeholder` props together. They will visually overlap and create a poor user experience.
+
+The Input component uses **floating labels** that animate from inside the input field. Using both label and placeholder simultaneously will cause them to overlap and interfere with each other.
+
+### ✅ Use Label (Recommended)
+
+```tsx
+<Input
+  label="Email Address"
+  value={email}
+  onChange={(e) => setEmail(e.target.value)}
+/>
+```
+
+### ✅ Use Placeholder (Alternative)
+
+```tsx
+<Input
+  placeholder="Enter your email address"
+  value={email}
+  onChange={(e) => setEmail(e.target.value)}
+/>
+```
+
+### ❌ Don't Combine Both
+
+```tsx
+{/* This will cause visual overlap - DON'T DO THIS */}
+<Input
+  label="Email Address"
+  placeholder="Enter your email address"
+  value={email}
+  onChange={(e) => setEmail(e.target.value)}
+/>
+```
+
 ## Best Practices
 
-1. **Labels**: Always provide clear, descriptive labels
-2. **Error Messages**: Make error messages helpful and actionable
-3. **Validation**: Validate on blur or submit, not on every keystroke
-4. **Clear Button**: Use for optional fields where clearing is helpful
-5. **Types**: Use the appropriate input type for the data being collected
+**Labels**: Always provide clear, descriptive labels
+
+**Error Messages**: Make error messages helpful and actionable
+
+**Validation**: Validate on blur or submit, not on every keystroke
+
+**Clear Button**: Use for optional fields where clearing is helpful
+
+**Types**: Use the appropriate input type for the data being collected
+
+**Label vs Placeholder**: Choose one approach - don't mix floating labels with placeholders

--- a/libs/ui-react/src/lib/Components/Input/Input.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Input/Input.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Input } from './Input';
+import { Button } from '../Button';
 import { InformationFill, SparksFill } from '../../Symbols';
 
 const meta: Meta<typeof Input> = {
@@ -39,19 +40,18 @@ const meta: Meta<typeof Input> = {
       description: 'Error message to display below the input',
     },
     value: {
-      control: 'text',
+      control: false,
       description: 'Controlled value of the input',
     },
-    renderRightElement: {
+    rightElement: {
       control: 'select',
       options: [undefined, 'Information'],
       defaultValue: undefined,
       mapping: {
         undefined: undefined,
-        Information: () => <InformationFill size={20} className="text-muted" />,
+        Information: <InformationFill size={20} className="text-muted" />,
       },
-      description:
-        'Function to render custom content on the right side of the input',
+      description: 'Custom content to render on the right side of the input',
     },
     onClear: {
       control: 'select',
@@ -78,24 +78,25 @@ type Story = StoryObj<typeof Input>;
 export const Default: Story = {
   render: (args) => {
     const [value, setValue] = React.useState(args.value || '');
+
     return (
       <Input
         {...args}
         value={value}
         onChange={(e) => setValue(e.target.value)}
-        onClear={args.onClear}
-        renderRightElement={args.renderRightElement}
+        onClear={args.onClear ? () => setValue('') : undefined}
+        rightElement={args.rightElement}
       />
     );
   },
   args: {
-    label: 'Title',
+    label: 'Label',
     type: 'text',
     disabled: false,
     'aria-invalid': false,
     value: '',
     onClear: undefined,
-    renderRightElement: undefined,
+    rightElement: undefined,
   },
 };
 
@@ -107,7 +108,7 @@ export const WithContent: Story = {
     const [value, setValue] = React.useState('Initial content');
     return (
       <Input
-        label="Title"
+        label="Label"
         value={value}
         onChange={(e) => setValue(e.target.value)}
         onClear={() => setValue('')}
@@ -124,7 +125,7 @@ export const Focused: Story = {
     const [value, setValue] = React.useState('');
     return (
       <Input
-        label="Title"
+        label="Label"
         value={value}
         onChange={(e) => setValue(e.target.value)}
         onClear={() => setValue('')}
@@ -145,7 +146,7 @@ export const WithError: Story = {
       email === '' || /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 
     return (
-      <div className="space-y-16">
+      <>
         <Input
           label="Email"
           type="email"
@@ -157,11 +158,11 @@ export const WithError: Story = {
             !isValidEmail ? 'Please enter a valid email address' : undefined
           }
         />
-        <div className="text-muted body-3">
+        <div className="mt-12 text-muted body-3">
           Try typing a valid email address or clicking the clear button to
           remove the error state
         </div>
-      </div>
+      </>
     );
   },
 };
@@ -174,7 +175,7 @@ export const Disabled: Story = {
     const [value] = React.useState('Disabled content');
     return (
       <Input
-        label="Title"
+        label="Label"
         value={value}
         onChange={() => {
           console.log('onChange');
@@ -230,15 +231,16 @@ const InfoTooltip = () => {
 
   return (
     <>
-      <button
-        type="button"
-        className="rounded-full p-2 transition-colors hover:bg-muted-hover"
+      <Button
+        appearance="no-background"
+        size="xs"
+        iconOnly
         onMouseEnter={() => setShowTooltip(true)}
         onMouseLeave={() => setShowTooltip(false)}
         aria-label="Username requirements"
       >
         <InformationFill size={20} className="text-muted" />
-      </button>
+      </Button>
       {showTooltip && (
         <div className="absolute bottom-full right-0 mb-8 w-64 rounded-md bg-base p-8 shadow-lg">
           <p className="body-3">
@@ -251,80 +253,224 @@ const InfoTooltip = () => {
 };
 
 const GeneratePasswordButton = () => (
-  <button
-    type="button"
+  <Button
+    appearance="no-background"
+    size="xs"
+    iconOnly
     onClick={() => alert('Generate password')}
-    className="rounded-full p-2 transition-colors hover:bg-muted-hover"
     aria-label="Generate random password"
   >
     <SparksFill size={20} className="text-muted" />
-  </button>
+  </Button>
 );
 
 export const WithCustomElement: Story = {
   render: () => {
+    const [value, setValue] = React.useState('');
     return (
-      <div className="space-y-16">
+      <>
         <div className="grid grid-cols-1 gap-16 md:grid-cols-2">
-          {/* Example with tooltip */}
+          {/* Example with tooltip and clear button */}
           <div>
-            <h3 className="mb-8 body-1-semi-bold">With Tooltip</h3>
-            <Input label="Username" renderRightElement={InfoTooltip} />
+            <h3 className="mb-8 body-1-semi-bold">
+              With Tooltip and Clear Button
+            </h3>
+            <Input
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              label="Username"
+              rightElement={<InfoTooltip />}
+              onClear={() => {
+                setValue('');
+              }}
+              id="tooltip-input"
+            />
           </div>
 
-          {/* Example with action button */}
+          {/* Example with action button and no clear button */}
           <div>
-            <h3 className="mb-8 body-1-semi-bold">With Action Button</h3>
+            <h3 className="mb-8 body-1-semi-bold">
+              With Action Button and No Clear Button
+            </h3>
             <Input
               label="Generate Password"
               type="password"
-              renderRightElement={GeneratePasswordButton}
+              rightElement={<GeneratePasswordButton />}
             />
           </div>
         </div>
-        <div className="text-muted body-3">
-          The renderRightElement prop allows you to add custom interactive
-          elements like tooltips, clear buttons, or action buttons
+        <div className="mt-16 text-muted body-3">
+          The rightElement prop allows you to add custom interactive elements
+          like tooltips, or action buttons
         </div>
-      </div>
+        <div className="mt-16 text-error body-3">
+          **Important note:** if onClear is provided, the clear button will take
+          over your right element once user starts typing.
+        </div>
+      </>
     );
   },
 };
 
 /**
- * Interactive example showing how the input behaves with user interaction and external error handling.
+ * Interactive form example showing how Input components work together in a real form with validation and submission.
  */
 export const Interactive: Story = {
   render: () => {
-    const [value, setValue] = React.useState('');
-    const [hasError, setHasError] = React.useState(false);
+    const [formData, setFormData] = React.useState({
+      username: '',
+      email: '',
+      password: '',
+      confirmPassword: '',
+    });
+    const [errors, setErrors] = React.useState<Record<string, string>>({});
+    const [isSubmitted, setIsSubmitted] = React.useState(false);
 
-    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-      const newValue = e.target.value;
-      setValue(newValue);
+    const handleChange =
+      (field: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
+        const value = e.target.value;
+        setFormData((prev) => ({ ...prev, [field]: value }));
 
-      // Simple validation example
-      setHasError(newValue.length > 0 && newValue.length < 3);
+        // Clear error when user starts typing
+        if (errors[field]) {
+          setErrors((prev) => ({ ...prev, [field]: '' }));
+        }
+      };
+
+    const handleClear = (field: string) => () => {
+      setFormData((prev) => ({ ...prev, [field]: '' }));
+      setErrors((prev) => ({ ...prev, [field]: '' }));
     };
 
+    const validateForm = () => {
+      const newErrors: Record<string, string> = {};
+
+      if (!formData.username) {
+        newErrors.username = 'Username is required';
+      } else if (formData.username.length < 3) {
+        newErrors.username = 'Username must be at least 3 characters';
+      }
+
+      if (!formData.email) {
+        newErrors.email = 'Email is required';
+      } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
+        newErrors.email = 'Please enter a valid email address';
+      }
+
+      if (!formData.password) {
+        newErrors.password = 'Password is required';
+      } else if (formData.password.length < 6) {
+        newErrors.password = 'Password must be at least 6 characters';
+      }
+
+      if (!formData.confirmPassword) {
+        newErrors.confirmPassword = 'Please confirm your password';
+      } else if (formData.password !== formData.confirmPassword) {
+        newErrors.confirmPassword = 'Passwords do not match';
+      }
+
+      setErrors(newErrors);
+      return Object.keys(newErrors).length === 0;
+    };
+
+    const handleSubmit = (e: React.FormEvent) => {
+      e.preventDefault();
+      if (validateForm()) {
+        setIsSubmitted(true);
+        // Reset form after success
+        setTimeout(() => {
+          setIsSubmitted(false);
+          setFormData({
+            username: '',
+            email: '',
+            password: '',
+            confirmPassword: '',
+          });
+        }, 2000);
+      }
+    };
+
+    if (isSubmitted) {
+      return (
+        <div className="bg-success/10 rounded-md p-16 text-center">
+          <div className="text-success body-1-semi-bold">
+            ✓ Form submitted successfully!
+          </div>
+          <div className="mt-4 text-muted body-3">Resetting form...</div>
+        </div>
+      );
+    }
+
     return (
-      <div className="space-y-16">
-        <div>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-16">
+        <div className="flex flex-col gap-16">
           <Input
             label="Username"
-            value={value}
-            onChange={handleChange}
-            aria-invalid={hasError}
-            errorMessage={
-              hasError ? 'Must be at least 3 characters' : undefined
-            }
+            value={formData.username}
+            onChange={handleChange('username')}
+            onClear={handleClear('username')}
+            aria-invalid={!!errors.username}
+            errorMessage={errors.username}
+            rightElement={<InformationFill size={20} className="text-muted" />}
+          />
+
+          <Input
+            label="Email"
+            type="email"
+            value={formData.email}
+            onChange={handleChange('email')}
+            onClear={handleClear('email')}
+            aria-invalid={!!errors.email}
+            errorMessage={errors.email}
+          />
+
+          <Input
+            label="Password"
+            type="password"
+            value={formData.password}
+            onChange={handleChange('password')}
+            onClear={handleClear('password')}
+            aria-invalid={!!errors.password}
+            errorMessage={errors.password}
+          />
+
+          <Input
+            label="Confirm Password"
+            type="password"
+            value={formData.confirmPassword}
+            onChange={handleChange('confirmPassword')}
+            onClear={handleClear('confirmPassword')}
+            aria-invalid={!!errors.confirmPassword}
+            errorMessage={errors.confirmPassword}
           />
         </div>
-        <div className="text-muted body-3">
-          Try typing to see the clear button appear. Click the X to clear the
-          input. Validation requires minimum 3 characters.
+
+        <div className="flex gap-12">
+          <Button type="submit" appearance="base">
+            Create Account
+          </Button>
+          <Button
+            type="button"
+            appearance="gray"
+            onClick={() => {
+              setFormData({
+                username: '',
+                email: '',
+                password: '',
+                confirmPassword: '',
+              });
+              setErrors({});
+            }}
+          >
+            Reset
+          </Button>
         </div>
-      </div>
+
+        <div className="text-muted body-3">
+          This example demonstrates form validation, error handling, clear
+          buttons, and right elements working together.
+        </div>
+      </form>
     );
   },
 };

--- a/libs/ui-react/src/lib/Components/Input/Input.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Input/Input.stories.tsx
@@ -1,0 +1,319 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Input } from './Input';
+import { InformationFill, SparksFill } from '../../Symbols';
+
+const meta: Meta<typeof Input> = {
+  component: Input,
+  title: 'Components/Input/Overview',
+  parameters: {
+    docs: {
+      source: {
+        language: 'tsx',
+        format: true,
+        type: 'code',
+      },
+    },
+  },
+  argTypes: {
+    label: {
+      control: 'text',
+      description:
+        'The label text that floats above the input when focused or filled',
+    },
+    'aria-invalid': {
+      control: 'boolean',
+      description: 'Indicates whether the input value is invalid',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Whether the input is disabled',
+    },
+    type: {
+      control: 'select',
+      options: ['text', 'email', 'password', 'number', 'tel', 'url'],
+      description: 'The type of input',
+    },
+    errorMessage: {
+      control: 'text',
+      description: 'Error message to display below the input',
+    },
+    value: {
+      control: 'text',
+      description: 'Controlled value of the input',
+    },
+    renderRightElement: {
+      control: 'select',
+      options: [undefined, 'Information'],
+      defaultValue: undefined,
+      mapping: {
+        undefined: undefined,
+        Information: () => <InformationFill size={20} className="text-muted" />,
+      },
+      description:
+        'Function to render custom content on the right side of the input',
+    },
+    onClear: {
+      control: 'select',
+      options: [undefined, 'Clear'],
+      defaultValue: undefined,
+      mapping: {
+        undefined: undefined,
+        Clear: () => {},
+      },
+      description: 'Function to clear the input via a clear button',
+    },
+  },
+  // Default args moved to Default story
+};
+
+export default meta;
+type Story = StoryObj<typeof Input>;
+
+/**
+ * The default input with a label.
+ */
+export const Default: Story = {
+  render: (args) => {
+    const [value, setValue] = React.useState(args.value || '');
+    return (
+      <Input
+        {...args}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onClear={args.onClear}
+        renderRightElement={args.renderRightElement}
+      />
+    );
+  },
+  args: {
+    label: 'Title',
+    type: 'text',
+    disabled: false,
+    'aria-invalid': false,
+    value: '',
+    onClear: undefined,
+    renderRightElement: undefined,
+  },
+};
+
+/**
+ * Input with content showing the floating label behavior and clear button.
+ */
+export const WithContent: Story = {
+  render: () => {
+    const [value, setValue] = React.useState('Initial content');
+    return (
+      <Input
+        label="Title"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onClear={() => setValue('')}
+      />
+    );
+  },
+};
+
+/**
+ * Input in a focused state showing the accent border and ring.
+ */
+export const Focused: Story = {
+  render: () => {
+    const [value, setValue] = React.useState('');
+    return (
+      <Input
+        label="Title"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onClear={() => setValue('')}
+        autoFocus
+      />
+    );
+  },
+};
+
+/**
+ * Input in an error state with visual indicators.
+ */
+export const WithError: Story = {
+  render: () => {
+    const [email, setEmail] = React.useState('invalid.email');
+    // Consider empty input as valid to allow clearing
+    const isValidEmail =
+      email === '' || /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+
+    return (
+      <div className="space-y-16">
+        <Input
+          label="Email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          onClear={() => setEmail('')}
+          aria-invalid={!isValidEmail}
+          errorMessage={
+            !isValidEmail ? 'Please enter a valid email address' : undefined
+          }
+        />
+        <div className="text-muted body-3">
+          Try typing a valid email address or clicking the clear button to
+          remove the error state
+        </div>
+      </div>
+    );
+  },
+};
+
+/**
+ * Disabled input state.
+ */
+export const Disabled: Story = {
+  render: () => {
+    const [value] = React.useState('Disabled content');
+    return <Input label="Title" value={value} onChange={() => {}} disabled />;
+  },
+};
+
+/**
+ * Input with different types.
+ */
+export const EmailType: Story = {
+  render: () => {
+    const [value, setValue] = React.useState('');
+    return (
+      <Input
+        label="Email"
+        type="email"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onClear={() => setValue('')}
+      />
+    );
+  },
+};
+
+export const PasswordType: Story = {
+  render: () => {
+    const [value, setValue] = React.useState('');
+    return (
+      <Input
+        label="Password"
+        type="password"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onClear={() => setValue('')}
+      />
+    );
+  },
+};
+
+/**
+ * Interactive example showing how the input behaves with user interaction and external error handling.
+ */
+/**
+ * Input with an info icon that provides additional context.
+ */
+// Custom right elements
+const InfoTooltip = () => {
+  const [showTooltip, setShowTooltip] = React.useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        className="rounded-full p-2 transition-colors hover:bg-muted-hover"
+        onMouseEnter={() => setShowTooltip(true)}
+        onMouseLeave={() => setShowTooltip(false)}
+        aria-label="Username requirements"
+      >
+        <InformationFill size={20} className="text-muted" />
+      </button>
+      {showTooltip && (
+        <div className="absolute bottom-full right-0 mb-8 w-64 rounded-md bg-base p-8 shadow-lg">
+          <p className="body-3">
+            Username must be unique and at least 3 characters long
+          </p>
+        </div>
+      )}
+    </>
+  );
+};
+
+const GeneratePasswordButton = () => (
+  <button
+    type="button"
+    onClick={() => alert('Generate password')}
+    className="rounded-full p-2 transition-colors hover:bg-muted-hover"
+    aria-label="Generate random password"
+  >
+    <SparksFill size={20} className="text-muted" />
+  </button>
+);
+
+export const WithCustomElement: Story = {
+  render: () => {
+    return (
+      <div className="space-y-16">
+        <div className="grid grid-cols-1 gap-16 md:grid-cols-2">
+          {/* Example with tooltip */}
+          <div>
+            <h3 className="mb-8 body-1-semi-bold">With Tooltip</h3>
+            <Input label="Username" renderRightElement={InfoTooltip} />
+          </div>
+
+          {/* Example with action button */}
+          <div>
+            <h3 className="mb-8 body-1-semi-bold">With Action Button</h3>
+            <Input
+              label="Generate Password"
+              type="password"
+              renderRightElement={GeneratePasswordButton}
+            />
+          </div>
+        </div>
+        <div className="text-muted body-3">
+          The renderRightElement prop allows you to add custom interactive
+          elements like tooltips, clear buttons, or action buttons
+        </div>
+      </div>
+    );
+  },
+};
+
+/**
+ * Interactive example showing how the input behaves with user interaction and external error handling.
+ */
+export const Interactive: Story = {
+  render: () => {
+    const [value, setValue] = React.useState('');
+    const [hasError, setHasError] = React.useState(false);
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = e.target.value;
+      setValue(newValue);
+
+      // Simple validation example
+      setHasError(newValue.length > 0 && newValue.length < 3);
+    };
+
+    return (
+      <div className="space-y-16">
+        <div>
+          <Input
+            label="Username"
+            value={value}
+            onChange={handleChange}
+            aria-invalid={hasError}
+            errorMessage={
+              hasError ? 'Must be at least 3 characters' : undefined
+            }
+          />
+        </div>
+        <div className="text-muted body-3">
+          Try typing to see the clear button appear. Click the X to clear the
+          input. Validation requires minimum 3 characters.
+        </div>
+      </div>
+    );
+  },
+};

--- a/libs/ui-react/src/lib/Components/Input/Input.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Input/Input.stories.tsx
@@ -63,7 +63,12 @@ const meta: Meta<typeof Input> = {
           console.log('Clear');
         },
       },
-      description: 'Function to clear the input via a clear button',
+      description: 'Optional function to override the default clear behavior',
+    },
+    hideClearButton: {
+      control: 'boolean',
+      description:
+        'Hide the clear button (shown by default when input has content)',
     },
   },
   // Default args moved to Default story
@@ -80,13 +85,15 @@ export const Default: Story = {
     const [value, setValue] = React.useState(args.value || '');
 
     return (
-      <Input
-        {...args}
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        onClear={args.onClear ? () => setValue('') : undefined}
-        rightElement={args.rightElement}
-      />
+      <div className="max-w-md">
+        <Input
+          {...args}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onClear={args.onClear ? () => setValue('') : undefined}
+          rightElement={args.rightElement}
+        />
+      </div>
     );
   },
   args: {
@@ -97,6 +104,7 @@ export const Default: Story = {
     value: '',
     onClear: undefined,
     rightElement: undefined,
+    hideClearButton: false,
   },
 };
 
@@ -107,12 +115,87 @@ export const WithContent: Story = {
   render: () => {
     const [value, setValue] = React.useState('Initial content');
     return (
+      <div className="max-w-md">
+        <Input
+          label="Label"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onClear={() => setValue('')}
+        />
+      </div>
+    );
+  },
+};
+
+/**
+ * Input with default clear button behavior (no onClear provided).
+ * Shows how the clear button appears automatically and handles clearing.
+ */
+export const DefaultClearBehavior: Story = {
+  render: () => {
+    return (
+      <div className="max-w-4xl">
+        <div className="grid grid-cols-1 gap-16 md:grid-cols-2">
+          <ControlledInputExample />
+          <UncontrolledInputExample />
+          <div className="col-span-full text-muted body-3">
+            Clear buttons appear automatically when input has content. No
+            onClear prop needed - default behavior handles both controlled and
+            uncontrolled inputs.
+          </div>
+        </div>
+      </div>
+    );
+  },
+};
+
+// Separate components to avoid state interference
+const ControlledInputExample = () => {
+  const [value, setValue] = React.useState(
+    'Type here to see default clear button',
+  );
+  return (
+    <div className="max-w-md">
       <Input
-        label="Label"
+        label="Controlled Input (Default Clear)"
         value={value}
         onChange={(e) => setValue(e.target.value)}
-        onClear={() => setValue('')}
+        id="controlled-input"
       />
+    </div>
+  );
+};
+
+const UncontrolledInputExample = () => {
+  return (
+    <div className="max-w-md">
+      <Input
+        label="Uncontrolled Input (Default Clear)"
+        defaultValue="Default content"
+        id="uncontrolled-input"
+      />
+    </div>
+  );
+};
+
+/**
+ * Input with hidden clear button using hideClearButton prop.
+ */
+export const HiddenClearButton: Story = {
+  render: () => {
+    const [value, setValue] = React.useState('Content with no clear button');
+    return (
+      <div className="max-w-md space-y-16">
+        <Input
+          label="Clear Button Hidden"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          hideClearButton
+        />
+        <div className="text-muted body-3">
+          Use hideClearButton to prevent the clear button from appearing.
+        </div>
+      </div>
     );
   },
 };
@@ -124,13 +207,15 @@ export const Focused: Story = {
   render: () => {
     const [value, setValue] = React.useState('');
     return (
-      <Input
-        label="Label"
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        onClear={() => setValue('')}
-        autoFocus
-      />
+      <div className="max-w-md">
+        <Input
+          label="Label"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onClear={() => setValue('')}
+          autoFocus
+        />
+      </div>
     );
   },
 };
@@ -146,7 +231,7 @@ export const WithError: Story = {
       email === '' || /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 
     return (
-      <>
+      <div className="max-w-md">
         <Input
           label="Email"
           type="email"
@@ -162,7 +247,7 @@ export const WithError: Story = {
           Try typing a valid email address or clicking the clear button to
           remove the error state
         </div>
-      </>
+      </div>
     );
   },
 };
@@ -174,14 +259,16 @@ export const Disabled: Story = {
   render: () => {
     const [value] = React.useState('Disabled content');
     return (
-      <Input
-        label="Label"
-        value={value}
-        onChange={() => {
-          console.log('onChange');
-        }}
-        disabled
-      />
+      <div className="max-w-md">
+        <Input
+          label="Label"
+          value={value}
+          onChange={() => {
+            console.log('onChange');
+          }}
+          disabled
+        />
+      </div>
     );
   },
 };
@@ -193,13 +280,15 @@ export const EmailType: Story = {
   render: () => {
     const [value, setValue] = React.useState('');
     return (
-      <Input
-        label="Email"
-        type="email"
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        onClear={() => setValue('')}
-      />
+      <div className="max-w-md">
+        <Input
+          label="Email"
+          type="email"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onClear={() => setValue('')}
+        />
+      </div>
     );
   },
 };
@@ -208,13 +297,15 @@ export const PasswordType: Story = {
   render: () => {
     const [value, setValue] = React.useState('');
     return (
-      <Input
-        label="Password"
-        type="password"
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        onClear={() => setValue('')}
-      />
+      <div className="max-w-md">
+        <Input
+          label="Password"
+          type="password"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onClear={() => setValue('')}
+        />
+      </div>
     );
   },
 };
@@ -268,7 +359,7 @@ export const WithCustomElement: Story = {
   render: () => {
     const [value, setValue] = React.useState('');
     return (
-      <>
+      <div className="max-w-4xl">
         <div className="grid grid-cols-1 gap-16 md:grid-cols-2">
           {/* Example with tooltip and clear button */}
           <div>
@@ -307,7 +398,7 @@ export const WithCustomElement: Story = {
           **Important note:** if onClear is provided, the clear button will take
           over your right element once user starts typing.
         </div>
-      </>
+      </div>
     );
   },
 };
@@ -402,75 +493,79 @@ export const Interactive: Story = {
     }
 
     return (
-      <form onSubmit={handleSubmit} className="flex flex-col gap-16">
-        <div className="flex flex-col gap-16">
-          <Input
-            label="Username"
-            value={formData.username}
-            onChange={handleChange('username')}
-            onClear={handleClear('username')}
-            aria-invalid={!!errors.username}
-            errorMessage={errors.username}
-            rightElement={<InformationFill size={20} className="text-muted" />}
-          />
+      <div className="max-w-md">
+        <form onSubmit={handleSubmit} className="flex flex-col gap-16">
+          <div className="flex flex-col gap-16">
+            <Input
+              label="Username"
+              value={formData.username}
+              onChange={handleChange('username')}
+              onClear={handleClear('username')}
+              aria-invalid={!!errors.username}
+              errorMessage={errors.username}
+              rightElement={
+                <InformationFill size={20} className="text-muted" />
+              }
+            />
 
-          <Input
-            label="Email"
-            type="email"
-            value={formData.email}
-            onChange={handleChange('email')}
-            onClear={handleClear('email')}
-            aria-invalid={!!errors.email}
-            errorMessage={errors.email}
-          />
+            <Input
+              label="Email"
+              type="email"
+              value={formData.email}
+              onChange={handleChange('email')}
+              onClear={handleClear('email')}
+              aria-invalid={!!errors.email}
+              errorMessage={errors.email}
+            />
 
-          <Input
-            label="Password"
-            type="password"
-            value={formData.password}
-            onChange={handleChange('password')}
-            onClear={handleClear('password')}
-            aria-invalid={!!errors.password}
-            errorMessage={errors.password}
-          />
+            <Input
+              label="Password"
+              type="password"
+              value={formData.password}
+              onChange={handleChange('password')}
+              onClear={handleClear('password')}
+              aria-invalid={!!errors.password}
+              errorMessage={errors.password}
+            />
 
-          <Input
-            label="Confirm Password"
-            type="password"
-            value={formData.confirmPassword}
-            onChange={handleChange('confirmPassword')}
-            onClear={handleClear('confirmPassword')}
-            aria-invalid={!!errors.confirmPassword}
-            errorMessage={errors.confirmPassword}
-          />
-        </div>
+            <Input
+              label="Confirm Password"
+              type="password"
+              value={formData.confirmPassword}
+              onChange={handleChange('confirmPassword')}
+              onClear={handleClear('confirmPassword')}
+              aria-invalid={!!errors.confirmPassword}
+              errorMessage={errors.confirmPassword}
+            />
+          </div>
 
-        <div className="flex gap-12">
-          <Button type="submit" appearance="base">
-            Create Account
-          </Button>
-          <Button
-            type="button"
-            appearance="gray"
-            onClick={() => {
-              setFormData({
-                username: '',
-                email: '',
-                password: '',
-                confirmPassword: '',
-              });
-              setErrors({});
-            }}
-          >
-            Reset
-          </Button>
-        </div>
+          <div className="flex gap-12">
+            <Button type="submit" appearance="base">
+              Create Account
+            </Button>
+            <Button
+              type="button"
+              appearance="gray"
+              onClick={() => {
+                setFormData({
+                  username: '',
+                  email: '',
+                  password: '',
+                  confirmPassword: '',
+                });
+                setErrors({});
+              }}
+            >
+              Reset
+            </Button>
+          </div>
 
-        <div className="text-muted body-3">
-          This example demonstrates form validation, error handling, clear
-          buttons, and right elements working together.
-        </div>
-      </form>
+          <div className="text-muted body-3">
+            This example demonstrates form validation, error handling, clear
+            buttons, and right elements working together.
+          </div>
+        </form>
+      </div>
     );
   },
 };

--- a/libs/ui-react/src/lib/Components/Input/Input.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Input/Input.stories.tsx
@@ -43,7 +43,7 @@ const meta: Meta<typeof Input> = {
       control: false,
       description: 'Controlled value of the input',
     },
-    rightElement: {
+    suffix: {
       control: 'select',
       options: [undefined, 'Information'],
       defaultValue: undefined,
@@ -51,7 +51,8 @@ const meta: Meta<typeof Input> = {
         undefined: undefined,
         Information: <InformationFill size={20} className="text-muted" />,
       },
-      description: 'Custom content to render on the right side of the input',
+      description:
+        'Custom content to render after the input (right side in LTR)',
     },
     onClear: {
       control: 'select',
@@ -91,7 +92,7 @@ export const Default: Story = {
           value={value}
           onChange={(e) => setValue(e.target.value)}
           onClear={args.onClear ? () => setValue('') : undefined}
-          rightElement={args.rightElement}
+          suffix={args.suffix}
         />
       </div>
     );
@@ -103,7 +104,7 @@ export const Default: Story = {
     'aria-invalid': false,
     value: '',
     onClear: undefined,
-    rightElement: undefined,
+    suffix: undefined,
     hideClearButton: false,
   },
 };
@@ -370,7 +371,7 @@ export const WithCustomElement: Story = {
               value={value}
               onChange={(e) => setValue(e.target.value)}
               label="Username"
-              rightElement={<InfoTooltip />}
+              suffix={<InfoTooltip />}
               onClear={() => {
                 setValue('');
               }}
@@ -386,17 +387,18 @@ export const WithCustomElement: Story = {
             <Input
               label="Generate Password"
               type="password"
-              rightElement={<GeneratePasswordButton />}
+              suffix={<GeneratePasswordButton />}
             />
           </div>
         </div>
         <div className="mt-16 text-muted body-3">
-          The rightElement prop allows you to add custom interactive elements
-          like tooltips, or action buttons
+          The suffix prop allows you to add custom interactive elements like
+          tooltips, or action buttons
         </div>
         <div className="mt-16 text-error body-3">
-          **Important note:** if onClear is provided, the clear button will take
-          over your right element once user starts typing.
+          **Important note:** The clear button automatically appears when input
+          has content and will take priority over your suffix element. Use
+          hideClearButton to prevent this if you need persistent suffix content.
         </div>
       </div>
     );
@@ -503,9 +505,7 @@ export const Interactive: Story = {
               onClear={handleClear('username')}
               aria-invalid={!!errors.username}
               errorMessage={errors.username}
-              rightElement={
-                <InformationFill size={20} className="text-muted" />
-              }
+              suffix={<InformationFill size={20} className="text-muted" />}
             />
 
             <Input

--- a/libs/ui-react/src/lib/Components/Input/Input.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Input/Input.stories.tsx
@@ -59,7 +59,9 @@ const meta: Meta<typeof Input> = {
       defaultValue: undefined,
       mapping: {
         undefined: undefined,
-        Clear: () => {},
+        Clear: () => {
+          console.log('Clear');
+        },
       },
       description: 'Function to clear the input via a clear button',
     },
@@ -170,7 +172,16 @@ export const WithError: Story = {
 export const Disabled: Story = {
   render: () => {
     const [value] = React.useState('Disabled content');
-    return <Input label="Title" value={value} onChange={() => {}} disabled />;
+    return (
+      <Input
+        label="Title"
+        value={value}
+        onChange={() => {
+          console.log('onChange');
+        }}
+        disabled
+      />
+    );
   },
 };
 

--- a/libs/ui-react/src/lib/Components/Input/Input.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Input/Input.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Input } from './Input';
 import { Button } from '../Button';
+import { Tooltip, TooltipTrigger, TooltipContent } from '../Tooltip';
 import { InformationFill, SparksFill } from '../../Symbols';
 
 const meta: Meta<typeof Input> = {
@@ -150,8 +151,21 @@ export const DefaultClearBehavior: Story = {
   },
 };
 
+export const ExtendedClearBehavior = () => {
+  return (
+    <div className="max-w-md">
+      <Input
+        label="Extended Clear Behavior"
+        onClear={() => {
+          alert('Extended clear behavior');
+        }}
+      />
+    </div>
+  );
+};
+
 // Separate components to avoid state interference
-const ControlledInputExample = () => {
+export const ControlledInputExample = () => {
   const [value, setValue] = React.useState(
     'Type here to see default clear button',
   );
@@ -167,7 +181,7 @@ const ControlledInputExample = () => {
   );
 };
 
-const UncontrolledInputExample = () => {
+export const UncontrolledInputExample = () => {
   return (
     <div className="max-w-md">
       <Input
@@ -238,7 +252,6 @@ export const WithError: Story = {
           type="email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          onClear={() => setEmail('')}
           aria-invalid={!isValidEmail}
           errorMessage={
             !isValidEmail ? 'Please enter a valid email address' : undefined
@@ -287,7 +300,6 @@ export const EmailType: Story = {
           type="email"
           value={value}
           onChange={(e) => setValue(e.target.value)}
-          onClear={() => setValue('')}
         />
       </div>
     );
@@ -304,7 +316,6 @@ export const PasswordType: Story = {
           type="password"
           value={value}
           onChange={(e) => setValue(e.target.value)}
-          onClear={() => setValue('')}
         />
       </div>
     );
@@ -319,41 +330,28 @@ export const PasswordType: Story = {
  */
 // Custom right elements
 const InfoTooltip = () => {
-  const [showTooltip, setShowTooltip] = React.useState(false);
-
   return (
-    <>
-      <Button
-        appearance="no-background"
-        size="xs"
-        iconOnly
-        onMouseEnter={() => setShowTooltip(true)}
-        onMouseLeave={() => setShowTooltip(false)}
-        aria-label="Username requirements"
-      >
-        <InformationFill size={20} className="text-muted" />
-      </Button>
-      {showTooltip && (
-        <div className="absolute bottom-full right-0 mb-8 w-64 rounded-md bg-base p-8 shadow-lg">
-          <p className="body-3">
-            Username must be unique and at least 3 characters long
-          </p>
-        </div>
-      )}
-    </>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button type="button" aria-label="Username requirements">
+          <InformationFill size={20} className="text-muted" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top">
+        Username must be unique and at least 3 characters long
+      </TooltipContent>
+    </Tooltip>
   );
 };
 
 const GeneratePasswordButton = () => (
-  <Button
-    appearance="no-background"
-    size="xs"
-    iconOnly
+  <button
+    type="button"
     onClick={() => alert('Generate password')}
     aria-label="Generate random password"
   >
     <SparksFill size={20} className="text-muted" />
-  </Button>
+  </button>
 );
 
 export const WithCustomElement: Story = {
@@ -372,9 +370,6 @@ export const WithCustomElement: Story = {
               onChange={(e) => setValue(e.target.value)}
               label="Username"
               suffix={<InfoTooltip />}
-              onClear={() => {
-                setValue('');
-              }}
               id="tooltip-input"
             />
           </div>
@@ -387,6 +382,7 @@ export const WithCustomElement: Story = {
             <Input
               label="Generate Password"
               type="password"
+              hideClearButton
               suffix={<GeneratePasswordButton />}
             />
           </div>
@@ -394,11 +390,6 @@ export const WithCustomElement: Story = {
         <div className="mt-16 text-muted body-3">
           The suffix prop allows you to add custom interactive elements like
           tooltips, or action buttons
-        </div>
-        <div className="mt-16 text-error body-3">
-          **Important note:** The clear button automatically appears when input
-          has content and will take priority over your suffix element. Use
-          hideClearButton to prevent this if you need persistent suffix content.
         </div>
       </div>
     );
@@ -431,7 +422,6 @@ export const Interactive: Story = {
       };
 
     const handleClear = (field: string) => () => {
-      setFormData((prev) => ({ ...prev, [field]: '' }));
       setErrors((prev) => ({ ...prev, [field]: '' }));
     };
 

--- a/libs/ui-react/src/lib/Components/Input/Input.test.tsx
+++ b/libs/ui-react/src/lib/Components/Input/Input.test.tsx
@@ -7,7 +7,9 @@ import { Input } from './Input';
 // Helper function to create controlled input props
 const createControlledProps = (overrides = {}) => ({
   value: '',
-  onChange: () => {},
+  onChange: () => {
+    console.log('onChange');
+  },
   ...overrides,
 });
 

--- a/libs/ui-react/src/lib/Components/Input/Input.test.tsx
+++ b/libs/ui-react/src/lib/Components/Input/Input.test.tsx
@@ -234,7 +234,7 @@ describe('Input Component', () => {
       <Input
         label="Username"
         {...createControlledProps()}
-        rightElement={<CustomElement />}
+        suffix={<CustomElement />}
       />,
     );
     expect(screen.getByTestId('custom-element')).toBeInTheDocument();

--- a/libs/ui-react/src/lib/Components/Input/Input.test.tsx
+++ b/libs/ui-react/src/lib/Components/Input/Input.test.tsx
@@ -136,7 +136,8 @@ describe('Input Component', () => {
       />,
     );
     const inputElement = screen.getByRole('textbox');
-    expect(inputElement).toHaveClass('custom-class');
+    const containerElement = inputElement.parentElement;
+    expect(containerElement).toHaveClass('custom-class');
   });
 
   it('should render label with correct htmlFor attribute when id is provided', () => {
@@ -233,7 +234,7 @@ describe('Input Component', () => {
       <Input
         label="Username"
         {...createControlledProps()}
-        renderRightElement={() => <CustomElement />}
+        rightElement={<CustomElement />}
       />,
     );
     expect(screen.getByTestId('custom-element')).toBeInTheDocument();

--- a/libs/ui-react/src/lib/Components/Input/Input.test.tsx
+++ b/libs/ui-react/src/lib/Components/Input/Input.test.tsx
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { Input } from './Input';
+
+// Helper function to create controlled input props
+const createControlledProps = (overrides = {}) => ({
+  value: '',
+  onChange: () => {},
+  ...overrides,
+});
+
+describe('Input Component', () => {
+  it('should render correctly with floating label', () => {
+    render(<Input label="Username" {...createControlledProps()} />);
+    const inputElement = screen.getByRole('textbox');
+    const labelElement = screen.getByText('Username');
+    expect(inputElement).toBeInTheDocument();
+    expect(labelElement).toBeInTheDocument();
+    expect(inputElement).toHaveAttribute('placeholder', ' ');
+  });
+
+  it('should render with error state when aria-invalid is true', () => {
+    render(
+      <Input label="Email" {...createControlledProps()} aria-invalid={true} />,
+    );
+    const inputElement = screen.getByRole('textbox');
+    expect(inputElement).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('should be disabled when disabled prop is true', () => {
+    render(<Input label="Username" {...createControlledProps()} disabled />);
+    const inputElement = screen.getByRole('textbox');
+    expect(inputElement).toBeDisabled();
+  });
+
+  it('should handle onChange events', () => {
+    const handleChange = vi.fn();
+    render(
+      <Input
+        label="Username"
+        {...createControlledProps({ onChange: handleChange })}
+      />,
+    );
+    const inputElement = screen.getByRole('textbox');
+
+    fireEvent.change(inputElement, { target: { value: 'test' } });
+    expect(handleChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('should render with different input types', () => {
+    render(
+      <Input label="Password" type="password" {...createControlledProps()} />,
+    );
+    const inputElement = screen.getByLabelText('Password');
+    expect(inputElement).toHaveAttribute('type', 'password');
+  });
+
+  it('should forward ref correctly', () => {
+    const ref = { current: null };
+    render(<Input label="Username" {...createControlledProps()} ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLInputElement);
+  });
+
+  it('should set aria-describedby and show error message', () => {
+    const errorMessage = 'This field is required';
+    render(
+      <Input
+        label="Email"
+        id="test-input"
+        errorMessage={errorMessage}
+        {...createControlledProps()}
+      />,
+    );
+
+    const inputElement = screen.getByRole('textbox');
+    expect(inputElement).toHaveAttribute(
+      'aria-describedby',
+      'test-input-error',
+    );
+    expect(inputElement).toHaveAttribute('aria-invalid', 'true');
+
+    const errorElement = screen.getByText(errorMessage);
+    expect(errorElement).toBeInTheDocument();
+    expect(errorElement.parentElement).toHaveAttribute(
+      'id',
+      'test-input-error',
+    );
+    expect(errorElement.parentElement).toHaveAttribute('role', 'alert');
+  });
+
+  it('should show error message with icon', () => {
+    const errorMessage = 'This field is required';
+    render(
+      <Input
+        label="Email"
+        errorMessage={errorMessage}
+        {...createControlledProps()}
+      />,
+    );
+
+    const messageElement = screen.getByText(errorMessage);
+    expect(messageElement).toBeInTheDocument();
+
+    const errorIcon = document.querySelector('.text-error.flex-shrink-0');
+    expect(errorIcon).toBeInTheDocument();
+  });
+
+  it('should accept all standard HTML input props', () => {
+    render(
+      <Input
+        label="Username"
+        maxLength={10}
+        minLength={3}
+        required
+        autoComplete="username"
+        {...createControlledProps()}
+      />,
+    );
+    const inputElement = screen.getByRole('textbox');
+    expect(inputElement).toHaveAttribute('maxLength', '10');
+    expect(inputElement).toHaveAttribute('minLength', '3');
+    expect(inputElement).toHaveAttribute('required');
+    expect(inputElement).toHaveAttribute('autoComplete', 'username');
+  });
+
+  it('should apply custom className', () => {
+    render(
+      <Input
+        label="Username"
+        className="custom-class"
+        {...createControlledProps()}
+      />,
+    );
+    const inputElement = screen.getByRole('textbox');
+    expect(inputElement).toHaveClass('custom-class');
+  });
+
+  it('should render label with correct htmlFor attribute when id is provided', () => {
+    render(
+      <Input
+        label="Username"
+        id="username-input"
+        {...createControlledProps()}
+      />,
+    );
+    const labelElement = screen.getByText('Username');
+    expect(labelElement).toHaveAttribute('for', 'username-input');
+  });
+
+  it('should handle focus and blur events correctly', () => {
+    const handleFocus = vi.fn();
+    const handleBlur = vi.fn();
+
+    render(
+      <Input
+        label="Username"
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        {...createControlledProps()}
+      />,
+    );
+    const inputElement = screen.getByRole('textbox');
+
+    fireEvent.focus(inputElement);
+    expect(handleFocus).toHaveBeenCalledTimes(1);
+
+    fireEvent.blur(inputElement);
+    expect(handleBlur).toHaveBeenCalledTimes(1);
+  });
+
+  it('should show clear button when input has content and onClear is provided', () => {
+    const handleClear = vi.fn();
+    render(
+      <Input
+        label="Username"
+        {...createControlledProps({ value: 'test content' })}
+        onClear={handleClear}
+      />,
+    );
+    const clearButton = screen.getByRole('button', { name: /clear input/i });
+    expect(clearButton).toBeInTheDocument();
+  });
+
+  it('should not show clear button when input is empty', () => {
+    const handleClear = vi.fn();
+    render(
+      <Input
+        label="Username"
+        {...createControlledProps()}
+        onClear={handleClear}
+      />,
+    );
+    const clearButton = screen.queryByRole('button', { name: /clear input/i });
+    expect(clearButton).not.toBeInTheDocument();
+  });
+
+  it('should not show clear button when input is disabled', () => {
+    const handleClear = vi.fn();
+    render(
+      <Input
+        label="Username"
+        {...createControlledProps({ value: 'test content' })}
+        onClear={handleClear}
+        disabled
+      />,
+    );
+    const clearButton = screen.queryByRole('button', { name: /clear input/i });
+    expect(clearButton).not.toBeInTheDocument();
+  });
+
+  it('should call onClear when clear button is clicked', () => {
+    const handleClear = vi.fn();
+    render(
+      <Input
+        label="Username"
+        {...createControlledProps({ value: 'test content' })}
+        onClear={handleClear}
+      />,
+    );
+
+    const clearButton = screen.getByRole('button', { name: /clear input/i });
+    fireEvent.click(clearButton);
+    expect(handleClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('should render custom right element when provided', () => {
+    const CustomElement = () => <div data-testid="custom-element">Custom</div>;
+    render(
+      <Input
+        label="Username"
+        {...createControlledProps()}
+        renderRightElement={() => <CustomElement />}
+      />,
+    );
+    expect(screen.getByTestId('custom-element')).toBeInTheDocument();
+  });
+});

--- a/libs/ui-react/src/lib/Components/Input/Input.tsx
+++ b/libs/ui-react/src/lib/Components/Input/Input.tsx
@@ -4,27 +4,57 @@ import { BaseInput, type BaseInputProps } from './BaseInput';
 export type InputProps = Omit<BaseInputProps, 'prefix'>;
 
 /**
- * A customizable input component with floating label, clear button, error states, and focus/hover effects.
+ * A customizable input component with floating label, automatic clear button, error states, and focus/hover effects.
  *
- * The label floats up when the input is focused or has content using CSS-only animations.
- * A clear button (X icon) appears when onClear is provided and can be clicked to empty the input.
- * Error state is controlled via the standard `aria-invalid` attribute.
- * Error message is displayed below the input when errorMessage is provided.
- * The suffix element is rendered on the right side of the input when suffix is provided.
+ * ## Key Features
+ * - **Automatic clear button** appears when input has content
+ * - **Floating label** with smooth CSS-only animations
+ * - **Suffix elements** for icons, buttons, or custom content
+ * - **Error state styling** with aria-invalid and errorMessage support
+ * - **Container-based spacing** with padding and gap for clean layout
+ * - **Flexible styling** via className, containerClassName, and labelClassName
+ *
+ * ## Clear Button Behavior
+ * - Shows automatically when input has content and is not disabled
+ * - Works with both controlled and uncontrolled inputs using native value setter
+ * - Can be hidden with `hideClearButton={true}`
+ * - Extended behavior via optional `onClear` prop
+ *
+ * ## Layout & Spacing
+ * Uses container-based spacing (px-16 padding + gap-8) for consistent element positioning.
+ * Suffix elements are automatically hidden when clear button appears.
+ *
  *
  * @example
- * // Basic input with floating label and clear button
- * <Input label="Title" value={title} onChange={(e) => setTitle(e.target.value)} onClear={() => setTitle("")} />
+ * // Basic input with automatic clear button
+ * <Input label="Title" value={title} onChange={(e) => setTitle(e.target.value)} />
  *
  * // Input with error state
- * <Input label="Email" value={email} onChange={(e) => setEmail(e.target.value)} errorMessage="Invalid email" />
- *
- * // Input with suffix element
  * <Input
  *   label="Email"
  *   value={email}
  *   onChange={(e) => setEmail(e.target.value)}
- *   suffix={() => <InformationFill size={20} className="text-muted" />}
+ *   aria-invalid={!isValid}
+ *   errorMessage="Please enter a valid email address"
+ * />
+ *
+ * // Input with suffix element
+ * <Input
+ *   label="Search"
+ *   value={query}
+ *   onChange={(e) => setQuery(e.target.value)}
+ *   suffix={<SearchIcon size={20} className="text-muted" />}
+ *   hideClearButton={true} // Keep suffix visible
+ * />
+ *
+ * // Extend clear behavior with analytics
+ * <Input
+ *   label="Username"
+ *   value={username}
+ *   onChange={(e) => setUsername(e.target.value)}
+ *   onClear={() => {
+ *     analytics.track('username_cleared');
+ *   }}
  * />
  */
 export const Input = React.forwardRef<HTMLInputElement, InputProps>(

--- a/libs/ui-react/src/lib/Components/Input/Input.tsx
+++ b/libs/ui-react/src/lib/Components/Input/Input.tsx
@@ -1,16 +1,7 @@
 import React from 'react';
-import { cn } from '@ldls/utils-shared';
-import { DeleteCircleFill } from '../../Symbols';
 import { BaseInput, type BaseInputProps } from './BaseInput';
 
-export interface InputProps extends BaseInputProps {
-  /** An optional error message displayed below the input */
-  errorMessage?: string;
-  /** Function to render custom content on the right side of the input */
-  renderRightElement?: () => React.ReactNode;
-  /** Function to clear the input via a clear button */
-  onClear?: () => void;
-}
+export type InputProps = Omit<BaseInputProps, 'leftElement'>
 
 /**
  * A customizable input component with floating label, clear button, error states, and focus/hover effects.
@@ -19,7 +10,7 @@ export interface InputProps extends BaseInputProps {
  * A clear button (X icon) appears when onClear is provided and can be clicked to empty the input.
  * Error state is controlled via the standard `aria-invalid` attribute.
  * Error message is displayed below the input when errorMessage is provided.
- * The right element is rendered on the right side of the input when renderRightElement is provided.
+ * The right element is rendered on the right side of the input when rightElement is provided.
  *
  * @example
  * // Basic input with floating label and clear button
@@ -33,71 +24,12 @@ export interface InputProps extends BaseInputProps {
  *   label="Email"
  *   value={email}
  *   onChange={(e) => setEmail(e.target.value)}
- *   renderRightElement={() => <InformationFill size={20} className="text-muted" />}
+ *   rightElement={() => <InformationFill size={20} className="text-muted" />}
  * />
  */
 export const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  (
-    {
-      className,
-      errorMessage,
-      renderRightElement,
-      onClear,
-      disabled,
-      ...props
-    },
-    ref,
-  ) => {
-    const isError = Boolean(props['aria-invalid'] || errorMessage);
-    const hasContent = !!props.value && props.value.toString().length > 0;
-    const showClearButton = hasContent && !disabled && onClear;
-
-    // Generate error ID for aria-describedby
-    const errorId = `${props.id || 'input'}-error`;
-
-    return (
-      <>
-        <div className="relative w-full">
-          <BaseInput
-            ref={ref}
-            disabled={disabled}
-            aria-invalid={isError}
-            aria-describedby={errorMessage ? errorId : undefined}
-            className={className}
-            {...props}
-          />
-
-          {showClearButton ? (
-            <button
-              type="button"
-              onClick={onClear}
-              className="absolute right-12 top-1/2 -translate-y-1/2 cursor-pointer rounded-full p-2 transition-colors hover:bg-muted-hover"
-              aria-label="Clear input"
-            >
-              <DeleteCircleFill
-                size={20}
-                className={cn('text-muted', isError && 'text-error')}
-              />
-            </button>
-          ) : renderRightElement ? (
-            <div className="absolute right-12 top-1/2 -translate-y-1/2">
-              {renderRightElement()}
-            </div>
-          ) : null}
-        </div>
-
-        {errorMessage && (
-          <div
-            id={errorId}
-            className="mt-2 flex items-center gap-2 text-error body-3"
-            role="alert"
-          >
-            <DeleteCircleFill size={16} className="flex-shrink-0 text-error" />
-            <span>{errorMessage}</span>
-          </div>
-        )}
-      </>
-    );
+  (props, ref) => {
+    return <BaseInput ref={ref} {...props} />;
   },
 );
 

--- a/libs/ui-react/src/lib/Components/Input/Input.tsx
+++ b/libs/ui-react/src/lib/Components/Input/Input.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BaseInput, type BaseInputProps } from './BaseInput';
 
-export type InputProps = Omit<BaseInputProps, 'leftElement'>
+export type InputProps = Omit<BaseInputProps, 'prefix'>;
 
 /**
  * A customizable input component with floating label, clear button, error states, and focus/hover effects.
@@ -10,7 +10,7 @@ export type InputProps = Omit<BaseInputProps, 'leftElement'>
  * A clear button (X icon) appears when onClear is provided and can be clicked to empty the input.
  * Error state is controlled via the standard `aria-invalid` attribute.
  * Error message is displayed below the input when errorMessage is provided.
- * The right element is rendered on the right side of the input when rightElement is provided.
+ * The suffix element is rendered on the right side of the input when suffix is provided.
  *
  * @example
  * // Basic input with floating label and clear button
@@ -19,12 +19,12 @@ export type InputProps = Omit<BaseInputProps, 'leftElement'>
  * // Input with error state
  * <Input label="Email" value={email} onChange={(e) => setEmail(e.target.value)} errorMessage="Invalid email" />
  *
- * // Input with right element
+ * // Input with suffix element
  * <Input
  *   label="Email"
  *   value={email}
  *   onChange={(e) => setEmail(e.target.value)}
- *   rightElement={() => <InformationFill size={20} className="text-muted" />}
+ *   suffix={() => <InformationFill size={20} className="text-muted" />}
  * />
  */
 export const Input = React.forwardRef<HTMLInputElement, InputProps>(

--- a/libs/ui-react/src/lib/Components/Input/Input.tsx
+++ b/libs/ui-react/src/lib/Components/Input/Input.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { cn } from '@ldls/utils-shared';
+import { DeleteCircleFill } from '../../Symbols';
+import { BaseInput, type BaseInputProps } from './BaseInput';
+
+export interface InputProps extends BaseInputProps {
+  /** An optional error message displayed below the input */
+  errorMessage?: string;
+  /** Function to render custom content on the right side of the input */
+  renderRightElement?: () => React.ReactNode;
+  /** Function to clear the input via a clear button */
+  onClear?: () => void;
+}
+
+/**
+ * A customizable input component with floating label, clear button, error states, and focus/hover effects.
+ *
+ * The label floats up when the input is focused or has content using CSS-only animations.
+ * A clear button (X icon) appears when onClear is provided and can be clicked to empty the input.
+ * Error state is controlled via the standard `aria-invalid` attribute.
+ * Error message is displayed below the input when errorMessage is provided.
+ * The right element is rendered on the right side of the input when renderRightElement is provided.
+ *
+ * @example
+ * // Basic input with floating label and clear button
+ * <Input label="Title" value={title} onChange={(e) => setTitle(e.target.value)} onClear={() => setTitle("")} />
+ *
+ * // Input with error state
+ * <Input label="Email" value={email} onChange={(e) => setEmail(e.target.value)} errorMessage="Invalid email" />
+ *
+ * // Input with right element
+ * <Input
+ *   label="Email"
+ *   value={email}
+ *   onChange={(e) => setEmail(e.target.value)}
+ *   renderRightElement={() => <InformationFill size={20} className="text-muted" />}
+ * />
+ */
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  (
+    {
+      className,
+      errorMessage,
+      renderRightElement,
+      onClear,
+      disabled,
+      ...props
+    },
+    ref,
+  ) => {
+    const isError = Boolean(props['aria-invalid'] || errorMessage);
+    const hasContent = !!props.value && props.value.toString().length > 0;
+    const showClearButton = hasContent && !disabled && onClear;
+
+    // Generate error ID for aria-describedby
+    const errorId = `${props.id || 'input'}-error`;
+
+    return (
+      <>
+        <div className="relative w-full">
+          <BaseInput
+            ref={ref}
+            disabled={disabled}
+            aria-invalid={isError}
+            aria-describedby={errorMessage ? errorId : undefined}
+            className={className}
+            {...props}
+          />
+
+          {showClearButton ? (
+            <button
+              type="button"
+              onClick={onClear}
+              className="absolute right-12 top-1/2 -translate-y-1/2 cursor-pointer rounded-full p-2 transition-colors hover:bg-muted-hover"
+              aria-label="Clear input"
+            >
+              <DeleteCircleFill
+                size={20}
+                className={cn('text-muted', isError && 'text-error')}
+              />
+            </button>
+          ) : renderRightElement ? (
+            <div className="absolute right-12 top-1/2 -translate-y-1/2">
+              {renderRightElement()}
+            </div>
+          ) : null}
+        </div>
+
+        {errorMessage && (
+          <div
+            id={errorId}
+            className="mt-2 flex items-center gap-2 text-error body-3"
+            role="alert"
+          >
+            <DeleteCircleFill size={16} className="flex-shrink-0 text-error" />
+            <span>{errorMessage}</span>
+          </div>
+        )}
+      </>
+    );
+  },
+);
+
+Input.displayName = 'Input';

--- a/libs/ui-react/src/lib/Components/Input/index.ts
+++ b/libs/ui-react/src/lib/Components/Input/index.ts
@@ -1,0 +1,1 @@
+export { Input } from './Input';

--- a/libs/ui-react/src/lib/Components/index.ts
+++ b/libs/ui-react/src/lib/Components/index.ts
@@ -4,5 +4,6 @@ export * from './CardButton';
 export * from './Checkbox';
 export * from './Link';
 export * from './Switch';
+export * from './Input';
 export * from './Tag';
 export * from './Tooltip';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,7 +5,7 @@
     "emitDeclarationOnly": true,
     "importHelpers": true,
     "isolatedModules": true,
-    "lib": ["es2022"],
+    "lib": ["es2022", "dom"],
     "module": "esnext",
     "moduleResolution": "bundler",
     "noEmitOnError": true,


### PR DESCRIPTION
## Input Component 

- Introduced a new baseInput: Internal usage only
- Introduced a new Input component on top of baseInput featuring a floating label, clear button, and error handling.
- Added comprehensive documentation and usage examples in Storybook.
- Implemented unit tests to ensure functionality and accessibility compliance.