### PR TITLE
refactor: update Banner and CardButton components to remove `isFull` 

### DIFF
--- a/libs/ui-react/src/lib/Components/Banner/Banner.implementation.mdx
+++ b/libs/ui-react/src/lib/Components/Banner/Banner.implementation.mdx
@@ -165,18 +165,34 @@ function DismissibleBanner() {
 }
 ```
 
-### Full Width Banner
+### Natural Width Behavior
 
-Use the `isFull` prop to make the banner take the full width of its container:
+Banners automatically flow to fill their parent container width. No additional props are needed:
 
 ```tsx
 <Banner
   title="System Maintenance"
   description="Scheduled maintenance will occur tonight from 2:00 AM to 4:00 AM EST"
   appearance="warning"
-  isFull
   closeAction={{ onClick: () => handleDismiss(), ariaLabel: 'Dismiss' }}
 />
+```
+
+To control banner width, use container elements:
+
+```tsx
+{/* Full viewport width */}
+<Banner title="Full Width" description="This banner fills the viewport width" />
+
+{/* Constrained width */}
+<div className="max-w-4xl mx-auto">
+  <Banner title="Constrained" description="This banner is limited by its container" />
+</div>
+
+{/* Responsive width */}
+<div className="w-full lg:max-w-2xl">
+  <Banner title="Responsive" description="Width adapts based on screen size" />
+</div>
 ```
 
 ### Complete Example
@@ -226,7 +242,7 @@ function NotificationCenter() {
           appearance={notification.type as any}
           title={notification.title}
           description={notification.description}
-          isFull
+
           closeAction={notification.dismissible ? {
             onClick: () => dismissNotification(notification.id),
             ariaLabel: 'Close notification'
@@ -278,13 +294,14 @@ The following guidelines ensure consistent usage of the Banner component and mai
   appearance="info"
 />
 
-// Use isFull for full-width layouts
-<Banner
-  title="System Notice"
-  description="Maintenance scheduled for tonight"
-  isFull
-  appearance="warning"
-/>
+// Use container elements to control banner width
+<div className="w-full">
+  <Banner
+    title="System Notice"
+    description="Maintenance scheduled for tonight"
+    appearance="warning"
+  />
+</div>
 ```
 
 ❌ **Don't**

--- a/libs/ui-react/src/lib/Components/Banner/Banner.mdx
+++ b/libs/ui-react/src/lib/Components/Banner/Banner.mdx
@@ -54,16 +54,22 @@ Banners support various content configurations:
 
 > **Note**: The title is required. Description, actions, and close are optional and can be combined as needed. Actions require both label and onClick handler.
 
+### Width Behavior
+
+Banners naturally flow within their containers and take the full width by default:
+
+<Canvas of={BannerStories.NaturalWidth} />
+
 ### Responsive Layout
 
-Banners adapt to their container:
+Banners adapt to their container constraints:
 
 <Canvas of={BannerStories.ResponsiveLayout} />
 
 > **Key behaviors:**
 >
-> - Default width fits content
-> - Use `isFull` prop for full container width
+> - Banners flow naturally to fill their parent container width
+> - Container elements control the banner width, not the banner itself
 > - Title limited to 2 lines, description to 5 lines with truncation
 > - Icons and buttons maintain consistent sizing
 

--- a/libs/ui-react/src/lib/Components/Banner/Banner.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Banner/Banner.stories.tsx
@@ -46,12 +46,19 @@ const meta: Meta<typeof Banner> = {
 export default meta;
 type Story = StoryObj<typeof Banner>;
 type BannerAppearance = 'info' | 'success' | 'warning' | 'error';
+type BannerProps = React.ComponentProps<typeof Banner>;
 
 export const Base: Story = {
   args: {
     appearance: 'info',
     title: 'Information Banner',
   },
+  render: (args: BannerProps) => (
+    // max-w-md container for visual presentation - not required for Banner component
+    <div className="max-w-md">
+      <Banner {...args} />
+    </div>
+  ),
   parameters: {
     docs: {
       source: {
@@ -69,6 +76,11 @@ export const WithDescription: Story = {
     title: 'Banner with Description',
     description: 'This is additional information about the banner.',
   },
+  render: (args: BannerProps) => (
+    <div className="max-w-md">
+      <Banner {...args} />
+    </div>
+  ),
   parameters: {
     docs: {
       source: {
@@ -97,6 +109,11 @@ export const WithActions: Story = {
       onClick: () => console.log('Secondary clicked'),
     },
   },
+  render: (args: BannerProps) => (
+    <div className="max-w-md">
+      <Banner {...args} />
+    </div>
+  ),
   parameters: {
     docs: {
       source: {
@@ -131,6 +148,11 @@ export const WithFullFeatures: Story = {
       ariaLabel: 'Close banner',
     },
   },
+  render: (args: BannerProps) => (
+    <div className="max-w-md">
+      <Banner {...args} />
+    </div>
+  ),
   parameters: {
     docs: {
       source: {
@@ -159,7 +181,8 @@ export const AppearanceShowcase: Story = {
     ];
 
     return (
-      <div className="flex flex-col gap-16 p-8">
+      // max-w-md container for visual presentation - not required for Banner component
+      <div className="flex max-w-md flex-col gap-16 p-8">
         {appearances.map(({ name, appearance }) => (
           <Banner
             key={appearance}
@@ -179,7 +202,8 @@ export const AppearanceShowcase: Story = {
 
 export const ContentVariations: Story = {
   render: () => (
-    <div className="flex flex-col gap-16 p-8">
+    // max-w-md container for visual presentation - not required for Banner component
+    <div className="flex max-w-md flex-col gap-16 p-8">
       <Banner title="Title Only" />
       <Banner title="With Description" description="Additional details here." />
       <Banner
@@ -230,6 +254,28 @@ export const ContentVariations: Story = {
   ),
 };
 
+export const NaturalWidth: Story = {
+  render: () => (
+    <div className="space-y-4">
+      <p className="text-muted body-3">
+        Banner without container constraints - takes full parent width:
+      </p>
+      <Banner
+        title="Full Width Banner"
+        description="This banner demonstrates natural width behavior - it fills the full width of its parent container."
+        primaryAction={{
+          label: 'Action',
+          onClick: () => console.log('Action clicked'),
+        }}
+        closeAction={{
+          onClick: () => console.log('Closed'),
+          ariaLabel: 'Close full width banner',
+        }}
+      />
+    </div>
+  ),
+};
+
 export const ResponsiveLayout: Story = {
   render: () => (
     <div className="grid w-384 grid-cols-1 gap-16 bg-muted-pressed p-16">
@@ -243,12 +289,11 @@ export const ResponsiveLayout: Story = {
         }}
       />
       <Banner
-        title="Full Width"
-        description="Short description"
-        isFull
+        title="Constrained Width"
+        description="Banner width is controlled by this 384px container"
         closeAction={{
           onClick: () => console.log('Closed'),
-          ariaLabel: 'Close full width banner',
+          ariaLabel: 'Close constrained width banner',
         }}
       />
       <Banner
@@ -264,26 +309,28 @@ export const ResponsiveLayout: Story = {
 };
 
 export const InteractiveDismiss: Story = {
-  render: (args) => {
+  render: (args: BannerProps) => {
     const [visible, setVisible] = React.useState(true);
 
     if (!visible) return <p>Banner dismissed</p>;
 
     return (
-      <Banner
-        {...args}
-        title="Click close to dismiss"
-        closeAction={{
-          onClick: () => setVisible(false),
-          ariaLabel: 'Dismiss interactive banner',
-        }}
-      />
+      <div className="max-w-md">
+        <Banner
+          {...args}
+          title="Click close to dismiss"
+          closeAction={{
+            onClick: () => setVisible(false),
+            ariaLabel: 'Dismiss interactive banner',
+          }}
+        />
+      </div>
     );
   },
 };
 
 export const InteractiveActions: Story = {
-  render: (args) => {
+  render: (args: BannerProps) => {
     const [state, setState] = React.useState('idle');
 
     const handleAccept = () => {
@@ -295,33 +342,39 @@ export const InteractiveActions: Story = {
     };
 
     return (
-      <Banner
-        {...args}
-        appearance={
-          state === 'success' ? 'success' : state === 'error' ? 'error' : 'info'
-        }
-        title={
-          state === 'success'
-            ? 'Accepted!'
-            : state === 'error'
-              ? 'Rejected!'
-              : 'Banner with Action'
-        }
-        primaryAction={
-          state === 'idle'
-            ? { label: 'Accept', onClick: handleAccept }
-            : undefined
-        }
-        secondaryAction={
-          state === 'idle'
-            ? { label: 'Reject', onClick: handleReject }
-            : undefined
-        }
-        closeAction={{
-          onClick: () => setState('idle'),
-          ariaLabel: 'Reset banner state',
-        }}
-      />
+      <div className="max-w-md">
+        <Banner
+          {...args}
+          appearance={
+            state === 'success'
+              ? 'success'
+              : state === 'error'
+                ? 'error'
+                : 'info'
+          }
+          title={
+            state === 'success'
+              ? 'Accepted!'
+              : state === 'error'
+                ? 'Rejected!'
+                : 'Banner with Action'
+          }
+          primaryAction={
+            state === 'idle'
+              ? { label: 'Accept', onClick: handleAccept }
+              : undefined
+          }
+          secondaryAction={
+            state === 'idle'
+              ? { label: 'Reject', onClick: handleReject }
+              : undefined
+          }
+          closeAction={{
+            onClick: () => setState('idle'),
+            ariaLabel: 'Reset banner state',
+          }}
+        />
+      </div>
     );
   },
 };

--- a/libs/ui-react/src/lib/Components/Banner/Banner.test.tsx
+++ b/libs/ui-react/src/lib/Components/Banner/Banner.test.tsx
@@ -97,12 +97,6 @@ describe('Banner Component', () => {
     expect(handleClose).toHaveBeenCalledTimes(1);
   });
 
-  it('should apply isFull prop', () => {
-    const { container } = render(<Banner title="Full Width Banner" isFull />);
-
-    expect(container.firstChild).toHaveClass('w-full');
-  });
-
   it('should apply custom className', () => {
     const { container } = render(
       <Banner title="Custom Banner" className="mb-16" />,

--- a/libs/ui-react/src/lib/Components/Banner/Banner.tsx
+++ b/libs/ui-react/src/lib/Components/Banner/Banner.tsx
@@ -17,22 +17,16 @@ const iconMap = {
   error: <DeleteCircleFill className="text-error" />,
 };
 
-const bannerVariants = cva(
-  'align-start flex w-fit max-w-full gap-8 rounded-md p-16 text-base',
-  {
-    variants: {
-      appearance: {
-        info: 'bg-muted',
-        success: 'bg-success',
-        warning: 'bg-warning',
-        error: 'bg-error',
-      },
-      isFull: {
-        true: 'w-full',
-      },
+const bannerVariants = cva('align-start flex gap-8 rounded-md p-16 text-base', {
+  variants: {
+    appearance: {
+      info: 'bg-muted',
+      success: 'bg-success',
+      warning: 'bg-warning',
+      error: 'bg-error',
     },
   },
-);
+});
 
 export type BannerAppearance = NonNullable<
   VariantProps<typeof bannerVariants>['appearance']
@@ -54,7 +48,6 @@ export interface BannerProps
   appearance?: BannerAppearance;
   title: string;
   description?: string;
-  isFull?: boolean;
   primaryAction?: BannerAction;
   secondaryAction?: BannerAction;
   closeAction?: BannerCloseAction;
@@ -72,7 +65,6 @@ export interface BannerProps
  * @param {'info' | 'success' | 'warning' | 'error'} [appearance='info'] - The type of banner which affects color and icon.
  * @param {string} title - The main title of the banner.
  * @param {string} [description] - Optional descriptive text.
- * @param {boolean} [isFull=false] - If true, the banner expands to full width of its container.
  * @param {BannerAction} [primaryAction] - Optional primary action with label and onClick handler.
  * @param {BannerAction} [secondaryAction] - Optional secondary action with label and onClick handler.
  * @param {BannerCloseAction} [closeAction] - Optional close action with onClick handler and optional ariaLabel. Controls the visibility of the close button.
@@ -96,11 +88,10 @@ export interface BannerProps
  *   primaryAction={{ label: "Undo", onClick: () => console.log('Undo') }}
  * />
  *
- * // Full-width error banner with close
+ * // Error banner with close
  * <Banner
  *   title="Error"
  *   appearance="error"
- *   isFull={true}
  *   closeAction={{ onClick: () => console.log('Close'), ariaLabel: 'Close banner' }}
  * />
  */
@@ -112,7 +103,6 @@ export const Banner = React.forwardRef<HTMLDivElement, BannerProps>(
       description,
       primaryAction,
       secondaryAction,
-      isFull,
       className,
       closeAction,
       ...props
@@ -124,13 +114,7 @@ export const Banner = React.forwardRef<HTMLDivElement, BannerProps>(
     return (
       <div
         ref={ref}
-        className={cn(
-          className,
-          bannerVariants({
-            appearance,
-            isFull,
-          }),
-        )}
+        className={cn(className, bannerVariants({ appearance }))}
         {...props}
       >
         <div className="flex flex-shrink-0 items-start py-4">{icon}</div>

--- a/libs/ui-react/src/lib/Components/CardButton/CardButton.implementation.mdx
+++ b/libs/ui-react/src/lib/Components/CardButton/CardButton.implementation.mdx
@@ -95,17 +95,33 @@ By default, a ChevronRight icon will be rendered on the right side. Use the `hid
 />
 ```
 
-### Full Width
+### Natural Width Behavior
 
-Use the `isFull` prop to make the card button take the full width of its container:
+CardButtons automatically flow to fit their parent container width. No additional props are needed:
 
 ```tsx
 <CardButton
   title="Continue Setup"
   description="Complete your account configuration"
-  isFull
   appearance="base"
 />
+```
+
+To control card button width, use container elements:
+
+```tsx
+{/* Full container width */}
+<CardButton title="Full Width" description="This button fills the container width" />
+
+{/* Constrained width */}
+<div className="max-w-md">
+  <CardButton title="Constrained" description="This button is limited by its container" />
+</div>
+
+{/* Responsive width */}
+<div className="w-full lg:max-w-lg">
+  <CardButton title="Responsive" description="Width adapts based on screen size" />
+</div>
 ```
 
 ### Outline Appearance
@@ -156,12 +172,13 @@ The following guidelines ensure consistent usage of the CardButton component and
   className="hidden md:block"
 />
 
-// Use isFull for full-width layouts
-<CardButton
-  title="Continue"
-  description="Proceed to the next step"
-  isFull
-/>
+// Use container elements to control button width
+<div className="w-full">
+  <CardButton
+    title="Continue"
+    description="Proceed to the next step"
+  />
+</div>
 ```
 
 ❌ **Don't**

--- a/libs/ui-react/src/lib/Components/CardButton/CardButton.mdx
+++ b/libs/ui-react/src/lib/Components/CardButton/CardButton.mdx
@@ -58,16 +58,22 @@ CardButtons support standard interactive states for both appearance variants:
 
 <Canvas of={CardButtonStories.StatesShowcase} />
 
+### Width Behavior
+
+CardButtons naturally flow within their containers and adapt their width based on content:
+
+<Canvas of={CardButtonStories.NaturalWidth} />
+
 ## Responsive Layout
 
-CardButtons automatically adapt their width to fit their container while maintaining proper content layout:
+CardButtons automatically adapt to their container constraints while maintaining proper content layout:
 
 <Canvas of={CardButtonStories.ResponsiveLayout} />
 
 > **Key behaviors:**
 >
-> - Default width adapts to content
-> - Use `isFull` prop for full container width
+> - CardButtons flow naturally to fit their parent container width
+> - Container elements control the button width, not the component itself
 > - Long titles and descriptions automatically wrap and truncate as needed
 > - Icons (including the chevron) maintain fixed sizes for visual consistency
 

--- a/libs/ui-react/src/lib/Components/CardButton/CardButton.stories.tsx
+++ b/libs/ui-react/src/lib/Components/CardButton/CardButton.stories.tsx
@@ -180,7 +180,7 @@ export const NaturalWidth: Story = {
 <CardButton
   appearance="base"
   title="Natural Width Example"
-  description="This card button demonstrates natural width behavior"
+  description="This card button demonstrates how it flows naturally to fill the full width of its parent container without any max-width constraints"
   icon={CreditCard}
 />
 `,

--- a/libs/ui-react/src/lib/Components/CardButton/CardButton.stories.tsx
+++ b/libs/ui-react/src/lib/Components/CardButton/CardButton.stories.tsx
@@ -159,6 +159,36 @@ export const FullFeatures: Story = {
   },
 };
 
+export const NaturalWidth: Story = {
+  render: () => (
+    <div className="w-full bg-muted-pressed p-16">
+      <div className="mb-16 text-muted body-4-semi-bold">
+        CardButton naturally flows to fill parent container width
+      </div>
+      <CardButton
+        appearance="base"
+        title="Natural Width Example"
+        description="This card button demonstrates how it flows naturally to fill the full width of its parent container without any max-width constraints"
+        icon={CreditCard}
+      />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<CardButton
+  appearance="base"
+  title="Natural Width Example"
+  description="This card button demonstrates natural width behavior"
+  icon={CreditCard}
+/>
+`,
+      },
+    },
+  },
+};
+
 export const AppearanceShowcase: Story = {
   render: () => {
     const appearances: Array<{
@@ -170,7 +200,7 @@ export const AppearanceShowcase: Story = {
     ];
 
     return (
-      <div className="flex flex-col gap-16 p-8">
+      <div className="flex max-w-md flex-col gap-16 p-8">
         {appearances.map(({ name, appearance }) => (
           <CardButton
             key={appearance}
@@ -187,7 +217,7 @@ export const AppearanceShowcase: Story = {
 
 export const ContentVariations: Story = {
   render: () => (
-    <div className="flex flex-col gap-16 p-8">
+    <div className="flex max-w-md flex-col gap-16 p-8">
       <CardButton
         appearance="base"
         title="With Description"
@@ -220,7 +250,7 @@ export const ContentVariations: Story = {
 
 export const StatesShowcase: Story = {
   render: () => (
-    <div className="flex flex-col gap-16 p-8">
+    <div className="flex max-w-md flex-col gap-16 p-8">
       <CardButton
         appearance="base"
         title="Base Default"
@@ -266,7 +296,6 @@ export const ResponsiveLayout: Story = {
         title="Full Width"
         description="Short description"
         icon={Plus}
-        isFull
       />
       <CardButton
         appearance="base"

--- a/libs/ui-react/src/lib/Components/CardButton/CardButton.tsx
+++ b/libs/ui-react/src/lib/Components/CardButton/CardButton.tsx
@@ -5,16 +5,13 @@ import { IconSize } from '../Icon/Icon';
 import { ChevronRight } from '../../Symbols';
 
 const buttonVariants = cva(
-  'inline-flex h-fit w-fit max-w-full cursor-pointer items-center gap-12 rounded-sm p-12 transition-colors focus-visible:outline-2 focus-visible:outline-focus disabled:pointer-events-none disabled:text-disabled',
+  'inline-flex h-fit items-center gap-12 rounded-sm p-12 transition-colors focus-visible:outline-2 focus-visible:outline-focus disabled:text-disabled',
   {
     variants: {
       appearance: {
         base: 'bg-muted text-base hover:bg-muted-hover active:bg-muted-pressed disabled:bg-disabled',
         outline:
           'bg-base-transparent text-base outline-dashed outline-1 outline-muted-subtle hover:bg-base-transparent-hover hover:outline-muted-subtle-hover focus-visible:outline-none focus-visible:outline-offset-0 active:bg-base-transparent-pressed active:outline-muted-subtle-pressed disabled:bg-base-transparent disabled:outline-disabled',
-      },
-      isFull: {
-        true: 'w-full',
       },
     },
     defaultVariants: {
@@ -30,13 +27,12 @@ export interface CardButtonProps
   title: string;
   description?: string;
   hideChevron?: boolean;
-  isFull?: boolean;
 }
 
 /**
  * A customizable card button component that displays an optional icon, a required title, an optional description, and an optional chevron arrow.
  *
- * It supports different appearances and can be set to full width. The chevron can be hidden if needed.
+ * It supports different appearances. takes full width by default. The chevron can be hidden if needed.
  *
  * @see {@link https://ldls.vercel.app/?path=/docs/components-cardbutton-overview--docs Storybook}
  * @see {@link https://ldls.vercel.app/?path=/docs/components-cardbutton-implementation--docs#dos-and-donts Guidelines}
@@ -48,7 +44,6 @@ export interface CardButtonProps
  * @param {string} title - The main title of the card button.
  * @param {string} [description] - Optional descriptive text displayed below the title.
  * @param {boolean} [hideChevron=false] - If true, hides the chevron arrow on the right side.
- * @param {boolean} [isFull=false] - If true, the card button expands to the full width of its container.
  * @param {string} [className] - Additional custom CSS classes to apply. Do not use this prop to modify the component's core appearance - use the `appearance` prop instead.
  * @param {Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'children'>} [...] - All standard button props except children (e.g., `disabled`, `onClick`, `type`).
  *
@@ -74,16 +69,7 @@ export interface CardButtonProps
  */
 export const CardButton = React.forwardRef<HTMLButtonElement, CardButtonProps>(
   (
-    {
-      className,
-      appearance,
-      icon,
-      title,
-      description,
-      hideChevron,
-      isFull,
-      ...props
-    },
+    { className, appearance, icon, title, description, hideChevron, ...props },
     ref,
   ) => {
     const IconComponent = icon;
@@ -95,7 +81,6 @@ export const CardButton = React.forwardRef<HTMLButtonElement, CardButtonProps>(
           className,
           buttonVariants({
             appearance,
-            isFull,
           }),
         )}
         disabled={props.disabled}


### PR DESCRIPTION
- Removed `isFull` prop from Banner and CardButton components, as they now naturally fill their parent container width.
- Updated documentation to clarify that container elements control the width of the components.
- Adjusted examples in implementation and stories to reflect the new width behavior.