### PR TITLE
feat: refactor imports to use local utils for ui-rnative 

### DIFF
--- a/.nx/version-plans/version-plan-1758268524685.md
+++ b/.nx/version-plans/version-plan-1758268524685.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/ldls-ui-rnative': patch
+---
+
+chore: : refactor imports to use local utils instead of utils-shared

--- a/libs/ui-rnative/package.json
+++ b/libs/ui-rnative/package.json
@@ -10,9 +10,8 @@
     "mobile",
     "nativewind"
   ],
-  "main": "./dist/index.cjs.js",
-  "module": "./dist/index.esm.js",
-  "types": "./dist/index.esm.d.ts",
+  "main": "./src/index.ts",
+  "module": "./src/index.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/libs/ui-rnative/src/lib/Components/Button/Button.tsx
+++ b/libs/ui-rnative/src/lib/Components/Button/Button.tsx
@@ -2,7 +2,7 @@ import { Text, TouchableOpacity, TouchableOpacityProps } from 'react-native';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { IconSize } from '../Icon/Icon';
 import React from 'react';
-import { cn } from '@ldls/utils-shared';
+import { cn } from '../../utils';
 import { Spinner } from '../../Symbols';
 
 const buttonVariants = cva(

--- a/libs/ui-rnative/src/lib/Components/Icon/Icon.tsx
+++ b/libs/ui-rnative/src/lib/Components/Icon/Icon.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@ldls/utils-shared';
+import { cn } from '../../utils';
 import { cva } from 'class-variance-authority';
 import React, { forwardRef } from 'react';
 import { View } from 'react-native';

--- a/libs/ui-rnative/src/lib/Components/Icon/createIcon.ts
+++ b/libs/ui-rnative/src/lib/Components/Icon/createIcon.ts
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import { Svg, SvgProps } from 'react-native-svg';
 import { Icon, IconProps } from './Icon';
-import { toPascalCase } from '@ldls/utils-shared';
+import { toPascalCase } from '../../utils';
 
 /**
  * Create an Icon component for React Native
@@ -11,7 +11,7 @@ import { toPascalCase } from '@ldls/utils-shared';
  */
 const createIcon = (
   iconName: string,
-  iconJsx: React.ReactElement<SvgProps>
+  iconJsx: React.ReactElement<SvgProps>,
 ) => {
   const Component = forwardRef<Svg, Omit<IconProps, 'children'>>(
     ({ className, ...props }, ref) =>
@@ -21,7 +21,7 @@ const createIcon = (
         viewBox: iconJsx.props.viewBox,
         ...props,
         children: iconJsx.props.children,
-      })
+      }),
   );
 
   Component.displayName = toPascalCase(iconName);

--- a/libs/ui-rnative/src/lib/utils/cn.ts
+++ b/libs/ui-rnative/src/lib/utils/cn.ts
@@ -1,0 +1,6 @@
+import { ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/libs/ui-rnative/src/lib/utils/index.ts
+++ b/libs/ui-rnative/src/lib/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './cn';
+export * from './string-utils';

--- a/libs/ui-rnative/src/lib/utils/string-utils.spec.ts
+++ b/libs/ui-rnative/src/lib/utils/string-utils.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { toPascalCase } from './string-utils';
+
+describe('toPascalCase', () => {
+  it('should convert kebab-case to PascalCase', () => {
+    expect(toPascalCase('arrow-up')).toBe('ArrowUp');
+    expect(toPascalCase('chevron-down')).toBe('ChevronDown');
+    expect(toPascalCase('external-link')).toBe('ExternalLink');
+    expect(toPascalCase('settings-alt-2')).toBe('SettingsAlt2');
+  });
+
+  it('should convert snake_case to PascalCase', () => {
+    expect(toPascalCase('arrow_up')).toBe('ArrowUp');
+    expect(toPascalCase('chevron_down')).toBe('ChevronDown');
+    expect(toPascalCase('external_link')).toBe('ExternalLink');
+    expect(toPascalCase('settings_alt_2')).toBe('SettingsAlt2');
+  });
+
+  it('should convert space-separated words to PascalCase', () => {
+    expect(toPascalCase('arrow up')).toBe('ArrowUp');
+    expect(toPascalCase('chevron down')).toBe('ChevronDown');
+    expect(toPascalCase('external link')).toBe('ExternalLink');
+  });
+
+  it('should handle mixed separators', () => {
+    expect(toPascalCase('arrow-up_down')).toBe('ArrowUpDown');
+    expect(toPascalCase('external_link-icon')).toBe('ExternalLinkIcon');
+    expect(toPascalCase('settings alt-2_variant')).toBe('SettingsAlt2Variant');
+  });
+
+  it('should handle single words', () => {
+    expect(toPascalCase('arrow')).toBe('Arrow');
+    expect(toPascalCase('icon')).toBe('Icon');
+    expect(toPascalCase('button')).toBe('Button');
+  });
+
+  it('should handle empty string', () => {
+    expect(toPascalCase('')).toBe('');
+  });
+
+  it('should handle strings with numbers', () => {
+    expect(toPascalCase('icon-24')).toBe('Icon24');
+    expect(toPascalCase('chart_1')).toBe('Chart1');
+    expect(toPascalCase('version 2')).toBe('Version2');
+    expect(toPascalCase('api-v1-endpoint')).toBe('ApiV1Endpoint');
+  });
+
+  it('should handle multiple consecutive separators', () => {
+    expect(toPascalCase('arrow--up')).toBe('ArrowUp');
+    expect(toPascalCase('external__link')).toBe('ExternalLink');
+    expect(toPascalCase('icon  button')).toBe('IconButton');
+    expect(toPascalCase('mixed-_-separators')).toBe('MixedSeparators');
+  });
+
+  it('should handle separators at the beginning and end', () => {
+    expect(toPascalCase('-arrow-up')).toBe('ArrowUp');
+    expect(toPascalCase('_external-link_')).toBe('ExternalLink');
+    expect(toPascalCase(' icon button ')).toBe('IconButton');
+    expect(toPascalCase('--start-end--')).toBe('StartEnd');
+  });
+
+  it('should handle case variations in input', () => {
+    expect(toPascalCase('ARROW-UP')).toBe('ArrowUp');
+    expect(toPascalCase('ExTerNaL-LiNk')).toBe('ExternalLink');
+    expect(toPascalCase('mixed_CASE_string')).toBe('MixedCaseString');
+  });
+
+  it('should handle single character segments', () => {
+    expect(toPascalCase('a-b-c')).toBe('ABC');
+    expect(toPascalCase('x_y_z')).toBe('XYZ');
+    expect(toPascalCase('i o s')).toBe('IOS');
+  });
+});

--- a/libs/ui-rnative/src/lib/utils/string-utils.ts
+++ b/libs/ui-rnative/src/lib/utils/string-utils.ts
@@ -1,0 +1,11 @@
+/**
+ * Transforms a kebab-case or snake_case string into a PascalCase string.
+ * e.g., 'arrow-up' -> 'ArrowUp'
+ */
+export function toPascalCase(str: string): string {
+  if (!str) return '';
+  return str
+    .split(/[-_ ]+/)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join('');
+}


### PR DESCRIPTION
# Title
chore(ui-rnative): Move utility functions from utils-shared to local utils

# Description
This PR moves utility functions (`cn` and `toPascalCase`) from `@ldls/utils-shared` to the local utils directory in `ui-rnative`. This change is temporary because we are exposing the source files for ui-rnative 
