### PR TITLE
chore(eslint): apply autofix on figma code generation

### DIFF
--- a/.github/workflows/sync-figma.yml
+++ b/.github/workflows/sync-figma.yml
@@ -139,7 +139,9 @@ jobs:
           path: libs/design-core/symbols/
 
       - name: Generate React Symbol Components
-        run: npx nx run @ledgerhq/ldls-design-core:generate-symbols-react
+        run: |
+          npx nx run @ledgerhq/ldls-design-core:generate-symbols-react
+          npx nx run-many --target=lint --fix
 
       - name: Upload React symbols artifacts
         uses: actions/upload-artifact@v4

--- a/libs/design-core/generate-symbols.mts
+++ b/libs/design-core/generate-symbols.mts
@@ -54,7 +54,7 @@ const svgrConfig = {
   icon: true,
   jsxRuntime: 'automatic' as const,
   expandProps: false,
-  plugins: ['@svgr/plugin-svgo', '@svgr/plugin-jsx', '@svgr/plugin-prettier'],
+  plugins: ['@svgr/plugin-svgo', '@svgr/plugin-jsx'],
   native: isReactNative,
   svgoConfig: {
     plugins: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,6 @@
         "@storybook/testing-library": "^0.2.2",
         "@svgr/core": "^8.1.0",
         "@svgr/plugin-jsx": "^8.1.0",
-        "@svgr/plugin-prettier": "^8.1.0",
         "@svgr/plugin-svgo": "^8.1.0",
         "@svgr/rollup": "^8.1.0",
         "@swc-node/register": "~1.9.1",
@@ -11435,43 +11434,6 @@
       },
       "peerDependencies": {
         "@svgr/core": "*"
-      }
-    },
-    "node_modules/@svgr/plugin-prettier": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@svgr/plugin-prettier/-/plugin-prettier-8.1.0.tgz",
-      "integrity": "sha512-o4/uFI8G64tAjBZ4E7gJfH+VP7Qi3T0+M4WnIsP91iFnGPqs5WvPDkpZALXPiyWEtzfYs1Rmwy1Zdfu8qoZuKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "deepmerge": "^4.3.1",
-        "prettier": "^2.8.7"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      },
-      "peerDependencies": {
-        "@svgr/core": "*"
-      }
-    },
-    "node_modules/@svgr/plugin-prettier/node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@svgr/plugin-svgo": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "@storybook/testing-library": "^0.2.2",
     "@svgr/core": "^8.1.0",
     "@svgr/plugin-jsx": "^8.1.0",
-    "@svgr/plugin-prettier": "^8.1.0",
     "@svgr/plugin-svgo": "^8.1.0",
     "@svgr/rollup": "^8.1.0",
     "@swc-node/register": "~1.9.1",


### PR DESCRIPTION
Signed-off-by: Simon Bruneaud <simon.bruneaud@ledger.fr>

## Desc
- Autofix the formatting using eslint nx task
- As we rely on eslint, we no longer need the dependency `svgr/plugin-prettier` 