### PR TITLE
feat: add BaseButton component and IconButton 

### DIFF
--- a/.nx/version-plans/version-plan-1759503867263.md
+++ b/.nx/version-plans/version-plan-1759503867263.md
@@ -2,4 +2,4 @@
 '@ledgerhq/ldls-ui-react': patch
 ---
 
-Braking change(ui-react): Add IconButton and update the Button API
+Breaking change(ui-react): Add IconButton and update the Button API

--- a/.nx/version-plans/version-plan-1759503867263.md
+++ b/.nx/version-plans/version-plan-1759503867263.md
@@ -1,0 +1,5 @@
+---
+'@ledgerhq/ldls-ui-react': patch
+---
+
+Braking change(ui-react): Add IconButton and update the Button API

--- a/libs/ui-react/.storybook/preview.ts
+++ b/libs/ui-react/.storybook/preview.ts
@@ -55,6 +55,7 @@ const preview: Preview = {
           [
             'Button',
             'CardButton',
+            'IconButton',
             'Link',
             'InteractiveIcon',
             'SuggestionKeyboard',

--- a/libs/ui-react/src/lib/Components/AmountInput/AmountInput.stories.tsx
+++ b/libs/ui-react/src/lib/Components/AmountInput/AmountInput.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
 import { AmountInput } from './AmountInput';
-import { Button } from '../Button/Button';
+import { IconButton } from '../IconButton';
 import { TransferVertical } from '../../Symbols/Icons/TransferVertical';
 
 const meta = {
@@ -144,7 +144,7 @@ export const LargeAmountDisplay: Story = {
             <div className='mt-8 text-center text-error'>{errorMessage}</div>
           )}
         </div>
-        <Button
+        <IconButton
           icon={TransferVertical}
           size='sm'
           appearance='gray'

--- a/libs/ui-react/src/lib/Components/Banner/Banner.tsx
+++ b/libs/ui-react/src/lib/Components/Banner/Banner.tsx
@@ -8,7 +8,7 @@ import {
   DeleteCircleFill,
   Close,
 } from '../../Symbols';
-import { Button } from '../Button';
+import { IconButton } from '../IconButton';
 
 const iconMap = {
   info: <InformationFill className='text-base' />,
@@ -136,7 +136,7 @@ export const Banner = React.forwardRef<HTMLDivElement, BannerProps>(
           )}
         </div>
         {onClose && (
-          <Button
+          <IconButton
             appearance='transparent'
             size='xs'
             icon={Close}

--- a/libs/ui-react/src/lib/Components/Button/BaseButton.tsx
+++ b/libs/ui-react/src/lib/Components/Button/BaseButton.tsx
@@ -13,7 +13,7 @@ const baseButtonVariants = cva(
         base: 'bg-interactive text-on-interactive hover:bg-interactive-hover active:bg-interactive-pressed',
         gray: 'bg-muted text-base hover:bg-muted-hover active:bg-muted-pressed',
         accent:
-          'bg- bg-accent text-on-accent hover:bg-accent-hover active:bg-accent-pressed',
+          'bg-accent text-on-accent hover:bg-accent-hover active:bg-accent-pressed',
         transparent:
           'bg-muted-transparent text-base hover:bg-muted-transparent-hover active:bg-muted-transparent-pressed',
         'no-background':

--- a/libs/ui-react/src/lib/Components/Button/BaseButton.tsx
+++ b/libs/ui-react/src/lib/Components/Button/BaseButton.tsx
@@ -1,0 +1,181 @@
+import React from 'react';
+import { cva } from 'class-variance-authority';
+import { cn } from '@ldls/utils-shared';
+import { IconSize } from '../Icon/Icon';
+import { Slot } from '@radix-ui/react-slot';
+import { Spinner } from '../../Symbols/Icons/Spinner';
+
+const baseButtonVariants = cva(
+  'duration-250 inline-flex h-fit w-fit cursor-pointer items-center justify-center rounded-full transition-colors body-1-semi-bold focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus [&[data-disabled="true"]]:bg-disabled [&[data-disabled="true"]]:text-disabled',
+  {
+    variants: {
+      appearance: {
+        base: 'bg-interactive text-on-interactive hover:bg-interactive-hover active:bg-interactive-pressed',
+        gray: 'bg-muted text-base hover:bg-muted-hover active:bg-muted-pressed',
+        accent:
+          'bg- bg-accent text-on-accent hover:bg-accent-hover active:bg-accent-pressed',
+        transparent:
+          'bg-muted-transparent text-base hover:bg-muted-transparent-hover active:bg-muted-transparent-pressed',
+        'no-background':
+          'bg-transparent text-base hover:bg-base-transparent-hover active:bg-base-transparent-pressed disabled:bg-base-transparent',
+        red: 'bg-error text-error hover:bg-error-hover active:bg-error-pressed',
+      },
+      size: {
+        xs: 'p-8',
+        sm: 'p-12',
+        md: 'p-12',
+        lg: 'p-16',
+      },
+      isFull: {
+        true: 'w-full',
+      },
+    },
+    defaultVariants: {
+      appearance: 'base',
+      size: 'md',
+      isFull: false,
+    },
+  },
+);
+
+export interface BaseButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /**
+   * The visual style of the button.
+   */
+  appearance?:
+    | 'base'
+    | 'gray'
+    | 'accent'
+    | 'transparent'
+    | 'no-background'
+    | 'red';
+  /**
+   * The size variant of the button.
+   */
+  size?: 'xs' | 'sm' | 'md' | 'lg';
+  /**
+   * If true, the button expands to full width of its container.
+   */
+  isFull?: boolean;
+  /**
+   * Whether the button is disabled.
+   */
+  disabled?: boolean;
+  /**
+   * If true, shows a loading spinner instead of the icon.
+   * @default false
+   */
+  loading?: boolean;
+  /**
+   * Additional custom CSS classes to apply.
+   */
+  className?: string;
+  /**
+   * Optional prop to render the button as a child element.
+   */
+  asChild?: boolean;
+  /**
+   * An optional icon component to render inside the button.
+   */
+  icon?: React.ComponentType<{ size?: IconSize; className?: string }>;
+  /**
+   * Optional children to render inside the button.
+   */
+  children?: React.ReactNode;
+}
+
+export const BaseButton = React.forwardRef<HTMLButtonElement, BaseButtonProps>(
+  (
+    {
+      className,
+      appearance,
+      size,
+      isFull,
+      disabled,
+      asChild = false,
+      icon: Icon,
+      loading,
+      children,
+      onClick,
+      ...props
+    },
+    ref,
+  ) => {
+    const iconSize = size === 'lg' ? 24 : size === 'xs' ? 16 : 20;
+
+    const iconContent = loading ? (
+      <Spinner
+        size={iconSize}
+        className='shrink-0 animate-spin'
+        aria-label='Loading'
+      />
+    ) : (
+      Icon && <Icon size={iconSize} className='shrink-0' />
+    );
+
+    if (asChild) {
+      const child = React.Children.only(children);
+
+      if (React.isValidElement(child)) {
+        return (
+          <Slot
+            className={cn(
+              className,
+              baseButtonVariants({ appearance, size, isFull }),
+            )}
+            ref={ref}
+            data-disabled={disabled || undefined}
+            onClick={(
+              event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+            ) => {
+              // If the button is disabled, prevent the default action (e.g., navigation).
+              if (disabled || loading) {
+                event.preventDefault();
+                return;
+              }
+              // Otherwise, call the original onClick handler if it was provided.
+              onClick?.(event);
+            }}
+            {...props}
+          >
+            {React.cloneElement(
+              child,
+              undefined,
+              <>
+                {iconContent}
+                {child.props.children}
+              </>,
+            )}
+          </Slot>
+        );
+      }
+
+      // If the child is not a valid element (e.g., just text),
+      // which is incorrect usage of asChild, we fall back gracefully.
+      console.warn(
+        'Button `asChild` prop received a child that is not a valid React element.',
+      );
+      return <>{children}</>;
+    }
+
+    return (
+      <button
+        onClick={disabled || loading ? undefined : onClick}
+        className={cn(
+          baseButtonVariants({ appearance, size, isFull }),
+          className,
+        )}
+        ref={ref}
+        disabled={disabled}
+        data-disabled={disabled || undefined}
+        {...props}
+      >
+        {iconContent}
+        {children && <span className='line-clamp-2 text-left'>{children}</span>}
+      </button>
+    );
+  },
+);
+
+BaseButton.displayName = 'BaseButton';

--- a/libs/ui-react/src/lib/Components/Button/BaseButton.tsx
+++ b/libs/ui-react/src/lib/Components/Button/BaseButton.tsx
@@ -6,7 +6,7 @@ import { Slot, Slottable } from '@radix-ui/react-slot';
 import { Spinner } from '../../Symbols/Icons/Spinner';
 
 const baseButtonVariants = cva(
-  'duration-250 inline-flex h-fit w-fit cursor-pointer items-center justify-center rounded-full transition-colors body-1-semi-bold focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus [&[data-disabled="true"]]:bg-disabled [&[data-disabled="true"]]:text-disabled',
+  'inline-flex size-fit cursor-pointer items-center justify-center rounded-full transition-colors duration-200 body-1-semi-bold focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus [&[data-disabled="true"]]:bg-disabled [&[data-disabled="true"]]:text-disabled',
   {
     variants: {
       appearance: {

--- a/libs/ui-react/src/lib/Components/Button/Button.mdx
+++ b/libs/ui-react/src/lib/Components/Button/Button.mdx
@@ -3,7 +3,7 @@ import * as ButtonStories from './Button.stories';
 import { Button } from './Button';
 import { CustomTabs, Tab } from '../../../../.storybook/CustomTabs';
 
-<Meta title="Components/Button" of={ButtonStories} />
+<Meta title='Components/Button' of={ButtonStories} />
 
 # 🔘 Button
 
@@ -20,8 +20,10 @@ Buttons are key interactive elements that trigger actions and guide users throug
 
 <Canvas of={ButtonStories.IconText} />
 
-- **Label**: describes the action that occurs when the button is tapped
+- **Label(required)**: must be present and describe the action that occurs when the button is tapped
 - **Icon (optional)**: visually communicate the button's action, and helps draw attention
+
+> Note: For **icon-only buttons**, use the [IconButton](/docs/action-iconbutton--docs) component instead. It's specifically designed for icon-only interactions with proper accessibility support.
 
 ## Properties
 
@@ -45,24 +47,22 @@ There are five button appearances, which indicate its emphasis. From strongest t
 
 ### Content
 
-Buttons' contents can be of three types:
+Buttons' contents can be of two types:
 
 - text (default)
 - icon-text
-- icon
 
 <Canvas of={ButtonStories.ContentTypesShowcase} />
-
-> Note: Buttons of the smallest size XS can't have a label, so they default to an icon only.
 
 ### Size
 
 Buttons come in four different sizes:
 
-- XS (**32 px** tall) **[ICON ONLY]**
 - S (**44 px** tall)
 - M (default, **48 px** tall)
 - L (**56 px** tall)
+
+> Note: For XS size (32 px tall), use the [IconButton](/docs/action-iconbutton--docs) component instead.
 
 <Canvas of={ButtonStories.SizesShowcase} />
 
@@ -109,21 +109,16 @@ To be implemented:
 
 <Canvas of={ButtonStories.AsChild} />
 
-<div className="rounded-8 mt-8 bg-muted p-12 text-base">
-  <p className="mb-4 body-2-semi-bold">Important Notes:</p>
-  <ul className="space-y-2 body-2">
-    <li>When using asChild, the child element receives all button styles</li>
-    <li>
-      Icon and loading props are ignored with asChild - handle these in the
-      child element
-    </li>
-    <li>Perfect for navigation links that should look like buttons</li>
-    <li>
-      Maintains semantic HTML (e.g., &lt;a&gt; for links, &lt;button&gt; for
-      actions)
-    </li>
-  </ul>
-</div>
+<p className='mb-4 text-base body-2-semi-bold'>Important Notes:</p>
+<ul className='space-y-2 text-base body-2'>
+  <li>When using asChild, the child element receives all button styles</li>
+  <li>Icon and loading props are still applied to the child element.</li>
+  <li>Perfect for navigation links that should look like buttons</li>
+  <li>
+    Maintains semantic HTML (e.g., &lt;a&gt; for links, &lt;button&gt; for
+    actions)
+  </li>
+</ul>
 
 </Tab> <Tab label="Implementation ">
 

--- a/libs/ui-react/src/lib/Components/Button/Button.stories.tsx
+++ b/libs/ui-react/src/lib/Components/Button/Button.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Button } from './Button';
-import { Settings, Plus } from '../../Symbols';
+import { Settings, Plus, ExternalLink } from '../../Symbols';
 
 const meta: Meta<typeof Button> = {
   component: Button,
@@ -30,7 +30,7 @@ const meta: Meta<typeof Button> = {
     },
     size: {
       control: 'select',
-      options: ['xs', 'sm', 'md', 'lg'],
+      options: ['sm', 'md', 'lg'],
       description: 'The size of the button',
     },
     disabled: {
@@ -43,7 +43,7 @@ const meta: Meta<typeof Button> = {
     },
     icon: {
       control: 'select',
-      description: 'Optional icon component to display',
+      description: 'Optional icon component to display alongside text',
       options: ['None', 'Plus', 'Settings'],
       mapping: {
         None: undefined,
@@ -60,7 +60,7 @@ const meta: Meta<typeof Button> = {
       description: 'Whether the button is full width',
     },
     asChild: {
-      control: 'boolean',
+      control: false,
       description:
         'Render as child element instead of button (useful for links)',
     },
@@ -169,7 +169,6 @@ export const ContentTypesShowcase: Story = {
       <Button appearance='base' icon={Plus}>
         With Icon
       </Button>
-      <Button appearance='base' icon={Settings} aria-label='Settings' />
     </div>
   ),
 };
@@ -177,12 +176,6 @@ export const ContentTypesShowcase: Story = {
 export const SizesShowcase: Story = {
   render: () => (
     <div className='flex items-center gap-4'>
-      <Button
-        appearance='base'
-        size='xs'
-        icon={Settings}
-        aria-label='Settings'
-      />
       <Button appearance='base' size='sm'>
         Small
       </Button>
@@ -243,11 +236,10 @@ export const ResponsiveLayout2: Story = {
 export const InteractiveLoadingStates: Story = {
   render: () => {
     const [states, setStates] = React.useState<
-      Record<'text' | 'withIcon' | 'iconOnly', 'idle' | 'loading' | 'red'>
+      Record<'text' | 'withIcon', 'idle' | 'loading' | 'red'>
     >({
       text: 'idle',
       withIcon: 'idle',
-      iconOnly: 'idle',
     });
 
     const handleClick = async (key: keyof typeof states) => {
@@ -275,14 +267,6 @@ export const InteractiveLoadingStates: Story = {
         >
           {states.withIcon === 'red' ? 'Settings Error!' : 'With Icon'}
         </Button>
-
-        <Button
-          appearance='accent'
-          loading={states.iconOnly === 'loading'}
-          onClick={() => handleClick('iconOnly')}
-          icon={Settings}
-          aria-label='Settings'
-        />
       </div>
     );
   },
@@ -311,7 +295,7 @@ export const AsChild: Story = {
             <Link to='#'>Open Button documentation</Link>
           </Button>
 
-          <Button asChild appearance='accent'>
+          <Button asChild appearance='accent' icon={ExternalLink}>
             <a
               href='https://shop.ledger.com'
               target='_blank'
@@ -334,7 +318,7 @@ export const AsChild: Story = {
 </Button>
 
 // Button as an external link
-<Button asChild appearance="accent" size="sm">
+<Button asChild appearance="accent" icon={ExternalLink}>
   <a href="https://example.com" target="_blank" rel="noopener noreferrer">
     External Link
   </a>

--- a/libs/ui-react/src/lib/Components/Button/Button.test.tsx
+++ b/libs/ui-react/src/lib/Components/Button/Button.test.tsx
@@ -12,13 +12,10 @@ describe('Button Component', () => {
     expect(buttonElement).toBeInTheDocument();
   });
 
-  it('should render as an icon-only button and have an aria-label', () => {
-    render(<Button icon={Settings} aria-label='Application Settings' />);
-    const buttonElement = screen.getByRole('button', {
-      name: /application settings/i,
-    });
+  it('should render with icon and text', () => {
+    render(<Button icon={Settings}>Settings</Button>);
+    const buttonElement = screen.getByRole('button', { name: /settings/i });
     expect(buttonElement).toBeInTheDocument();
-    expect(buttonElement).toHaveClass('p-12');
   });
 
   it('should be disabled when the disabled prop is true', () => {

--- a/libs/ui-react/src/lib/Components/Button/Button.tsx
+++ b/libs/ui-react/src/lib/Components/Button/Button.tsx
@@ -1,118 +1,35 @@
 import React from 'react';
 import { cva } from 'class-variance-authority';
 import { cn } from '@ldls/utils-shared';
-import { Spinner } from '../../Symbols/Icons/Spinner';
-import { IconSize } from '../Icon/Icon';
-import { Slot } from '@radix-ui/react-slot';
+import { BaseButton, BaseButtonProps } from './BaseButton';
 
-const buttonVariants = cva(
-  'inline-flex size-fit cursor-pointer items-center justify-center rounded-full transition-colors body-1-semi-bold focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus disabled:bg-disabled disabled:text-disabled',
-  {
-    variants: {
-      appearance: {
-        base: 'bg-interactive text-on-interactive hover:bg-interactive-hover active:bg-interactive-pressed',
-        gray: 'bg-muted text-base hover:bg-muted-hover active:bg-muted-pressed',
-        accent:
-          'bg-accent text-on-accent hover:bg-accent-hover active:bg-accent-pressed',
-        transparent:
-          'bg-muted-transparent text-base hover:bg-muted-transparent-hover active:bg-muted-transparent-pressed',
-        'no-background':
-          'bg-transparent text-base hover:bg-base-transparent-hover active:bg-base-transparent-pressed disabled:bg-base-transparent',
-        red: 'bg-error text-error hover:bg-error-hover active:bg-error-pressed',
-      },
-      size: {
-        xs: 'px-12 py-8 body-2-semi-bold',
-        sm: 'px-16 py-12 body-2-semi-bold',
-        md: 'px-16 py-12',
-        lg: 'p-16',
-      },
-      isFull: {
-        true: 'w-full',
-      },
-      iconOnly: {
-        true: '',
-        false: '',
-      },
-    },
-    compoundVariants: [
-      {
-        size: 'xs',
-        iconOnly: true,
-        className: 'p-8',
-      },
-      {
-        size: 'sm',
-        iconOnly: true,
-        className: 'p-12',
-      },
-      {
-        size: 'md',
-        iconOnly: true,
-        className: 'p-12',
-      },
-      {
-        size: 'lg',
-        iconOnly: true,
-        className: 'p-16',
-      },
-      {
-        iconOnly: false,
-        className: 'gap-8',
-      },
-    ],
-    defaultVariants: {
-      appearance: 'base',
-      size: 'md',
-      isFull: false,
-      iconOnly: false,
+const buttonVariants = cva('', {
+  variants: {
+    size: {
+      sm: 'px-16 py-12 body-2-semi-bold',
+      md: 'px-16 py-12',
+      lg: 'p-16',
     },
   },
-);
+  defaultVariants: {
+    size: 'md',
+  },
+});
 
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  /**
-   * The visual style of the button.
-   */
-  appearance?:
-    | 'base'
-    | 'gray'
-    | 'accent'
-    | 'transparent'
-    | 'no-background'
-    | 'red';
-  /**
-   * The size variant of the button.
-   */
-  size?: 'xs' | 'sm' | 'md' | 'lg';
-  /**
-   * If true, the button expands to full width of its container.
-   */
-  isFull?: boolean;
+  extends Omit<BaseButtonProps, 'children' | 'size'> {
   /**
    * If true, shows a loading spinner and disables the button.
    */
   loading?: boolean;
   /**
-   * An optional icon component to render inside the button.
+   * The content of the button. This is required to ensure buttons always have a label.
    */
-  icon?: React.ComponentType<{ size?: IconSize; className?: string }>;
+  children: React.ReactNode;
   /**
-   * Whether the button is disabled.
+   * The size variant of the button.
    */
-  disabled?: boolean;
-  /**
-   * Additional custom CSS classes to apply.
-   */
-  className?: string;
-  /**
-   * The button's content, typically text or other elements.
-   */
-  children?: React.ReactNode;
-  /**
-   * If true, renders the child element directly with button styles instead of wrapping in a button element.
-   */
-  asChild?: boolean;
+  size?: 'sm' | 'md' | 'lg';
 }
 
 /**
@@ -134,11 +51,6 @@ export interface ButtonProps
  *   Click Me
  * </Button>
  *
- * // Icon-only button with loading state
- * import { Button } from '@ledgerhq/ldls-ui-react';
- * import { ArrowRight } from '@ledgerhq/ldls-ui-react/symbols';
- *
- * <Button icon={ArrowRight} size="sm" loading={isLoading} disabled={isLoading} />
  *
  * // Full-width button with custom class
  * <Button appearance="accent" isFull={true} className="ml-16">
@@ -152,96 +64,23 @@ export interface ButtonProps
  *   <Link to="/dashboard">Go to Dashboard</Link>
  * </Button>
  *
- * // Button as an anchor tag
- * <Button asChild appearance="accent" size="sm">
- *   <a href="https://example.com" target="_blank" rel="noopener noreferrer">
- *     External Link
- *   </a>
- * </Button>
- *
- * // Note: When using asChild, the child element is responsible for its own content.
- * // Icons, loading states, and other Button props like 'icon' and 'loading' are ignored
- * // when asChild is true - you should handle these in the child element if needed.
  */
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  (
-    {
-      className,
-      children,
-      appearance,
-      size = 'md',
-      isFull,
-      loading,
-      icon,
-      asChild = false,
-      onClick,
-      disabled,
-      ...props
-    },
-    ref,
-  ) => {
-    const iconOnly = Boolean(icon && !children);
-
-    const iconSizeMap: { [key: string]: IconSize } = {
-      xs: 16,
-      sm: 20,
-      md: 24,
-      lg: 24,
-    };
-
-    const calculatedIconSize = size ? iconSizeMap[size] : 24;
-    const IconComponent = icon;
-
-    const Comp = asChild ? Slot : 'button';
-
+  ({ className, loading, disabled, children, size, icon, ...props }, ref) => {
     return (
-      <Comp
+      <BaseButton
         ref={ref}
-        onClick={disabled || loading ? undefined : onClick}
-        className={cn(
-          className,
-          buttonVariants({
-            appearance,
-            size,
-            isFull,
-            iconOnly,
-          }),
-        )}
+        size={size}
         disabled={disabled}
+        icon={icon}
+        loading={loading}
+        className={cn(buttonVariants({ size }), 'gap-8', className)}
         {...props}
       >
-        {asChild ? (
-          children
-        ) : (
-          <>
-            {loading ? (
-              <>
-                <Spinner
-                  size={calculatedIconSize}
-                  className='shrink-0 animate-spin'
-                  aria-label='Loading'
-                />
-                {children && (
-                  <span className='line-clamp-2 text-left'>{children}</span>
-                )}
-              </>
-            ) : (
-              <>
-                {IconComponent && (
-                  <IconComponent
-                    size={calculatedIconSize}
-                    className='shrink-0'
-                  />
-                )}
-                {children && (
-                  <span className='line-clamp-2 text-left'>{children}</span>
-                )}
-              </>
-            )}
-          </>
-        )}
-      </Comp>
+        {children}
+      </BaseButton>
     );
   },
 );
+
 Button.displayName = 'Button';

--- a/libs/ui-react/src/lib/Components/Button/index.ts
+++ b/libs/ui-react/src/lib/Components/Button/index.ts
@@ -1,1 +1,2 @@
-export * from './Button';
+export { Button, type ButtonProps } from './Button';
+export { BaseButton, type BaseButtonProps } from './BaseButton';

--- a/libs/ui-react/src/lib/Components/IconButton/IconButton.mdx
+++ b/libs/ui-react/src/lib/Components/IconButton/IconButton.mdx
@@ -51,8 +51,8 @@ IconButtons come in four different sizes:
 
 ### Tooltip
 
-You can show a tooltip with the aria-label on hover via the `tooltip`prop.
-the tooltip placement is customizable via the `tooltipPlacement`prop and tooltip text is customizable as well via the `tooltipText`prop.
+You can show a tooltip with the aria-label on hover via the `tooltip` prop.
+The tooltip placement is customizable via the `tooltipPlacement` prop and tooltip text is customizable as well via the `tooltipText` prop.
 
 <Canvas of={IconButtonStories.TooltipTextVariations} />
 

--- a/libs/ui-react/src/lib/Components/IconButton/IconButton.mdx
+++ b/libs/ui-react/src/lib/Components/IconButton/IconButton.mdx
@@ -1,0 +1,276 @@
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
+import * as IconButtonStories from './IconButton.stories';
+import { IconButton } from './IconButton';
+import { CustomTabs, Tab } from '../../../../.storybook/CustomTabs';
+
+<Meta title='Action/IconButton' of={IconButtonStories} />
+
+# 🔘 IconButton
+
+<CustomTabs>
+  <Tab label="Overview">
+
+## Introduction
+
+**IconButton** is a specialized button component that displays only an icon. It's ideal for actions that can be represented by a clear, universally understood icon, such as `close`, `settings`, or `favorite`.
+
+## Properties
+
+### Overview
+
+<Canvas of={IconButtonStories.Base} />
+<Controls of={IconButtonStories.Base} />
+
+### Appearance
+
+IconButton supports the same appearances as the standard Button:
+
+- accent
+- base (default)
+- gray
+- transparent
+- no-background
+- red
+
+<Canvas of={IconButtonStories.AppearanceShowcase} />
+
+### Size
+
+IconButtons come in four different sizes:
+
+- xs (32px)
+- sm (44px)
+- md (48px, default)
+- lg (56px)
+
+<Canvas of={IconButtonStories.SizesShowcase} />
+
+### States
+
+<Canvas of={IconButtonStories.StatesShowcase} />
+
+### Tooltip
+
+You can show a tooltip with the aria-label on hover via the `tooltip`prop.
+the tooltip placement is customizable via the `tooltipPlacement`prop and tooltip text is customizable as well via the `tooltipText`prop.
+
+<Canvas of={IconButtonStories.TooltipTextVariations} />
+
+## As Child
+
+The `asChild` prop allows integration with routing by merging IconButton styles with child elements.
+This is useful when you want to use the IconButton as a child of a Link component.
+
+<Canvas of={IconButtonStories.AsChild} />
+
+  </Tab>
+  <Tab label="Implementation">
+
+## Installation
+
+Install the packages and their peer dependencies:
+
+```bash
+# Install the UI Kit
+npm install @ledgerhq/ldls-ui-react @ledgerhq/ldls-design-core
+
+# Install peer dependencies
+npm install tailwindcss@^3.4.0 react@^18.3.1 clsx tailwind-merge class-variance-authority @radix-ui/react-slot
+```
+
+#### **About @radix-ui/react-slot**
+
+The `@radix-ui/react-slot` dependency is used internally by the IconButton component
+to enable flexible composition patterns. It allows the IconButton to merge its props with child
+elements when needed.
+
+### Tailwind Configuration
+
+To use the IconButton component with our custom Tailwind preset, you need to configure your `tailwind.config.ts`:
+
+```typescript
+import type { Config } from 'tailwindcss';
+import { ledgerLivePreset } from '@ledgerhq/ldls-design-core';
+
+const config = {
+  content: [
+    "./src/**/*.{js,ts,jsx,tsx}", // Your project's files
+    "./node_modules/@ledgerhq/ldls-ui-react/dist/lib/**/*.{js,ts,jsx,tsx}" // Ledger UI Kit components
+  ],
+  presets: [ledgerLivePreset], // the installed tailwind preset
+} satisfies Config;
+
+export default config;
+```
+
+### Basic Usage
+
+```tsx
+import { IconButton } from '@ledgerhq/ldls-ui-react';
+import { Settings } from '@ledgerhq/ldls-ui-react/symbols';
+
+function MyComponent() {
+  return (
+    <IconButton
+      aria-label="Open settings"
+      icon={Settings}
+      size="md"
+      appearance="base"
+      tooltip // Shows a tooltip with the aria-label on hover
+    />
+  );
+}
+```
+
+### Custom Styling
+
+While the component comes with predefined styles, you can extend them using Tailwind classes for layout purposes:
+
+```tsx
+<IconButton
+  aria-label="Close menu"
+  icon={Close}
+  className="absolute top-4 right-4" // Position the button
+/>
+```
+
+### Using with Routers (asChild)
+
+The `asChild` prop allows integration with routing libraries by merging IconButton styles with child elements:
+
+```tsx
+import { IconButton } from '@ledgerhq/ldls-ui-react';
+import { Link } from 'react-router-dom';
+import { Settings } from '@ledgerhq/ldls-ui-react/symbols';
+
+function MyComponent() {
+  return (
+    <IconButton asChild appearance="accent" aria-label="Go to settings">
+      <Link to="/settings">
+        <Settings />
+      </Link>
+    </IconButton>
+  );
+}
+```
+
+Note: When using asChild, the child element handles its own content. The icon prop is ignored - implement equivalent functionality in the child if needed.
+
+## Do's and Don'ts
+
+### Icon Usage
+
+✅ **Do**
+
+```tsx
+// Import icons explicitly
+import { Settings } from '@ledgerhq/ldls-ui-react/symbols';
+
+// Use icon prop for consistent sizing
+<IconButton aria-label="Settings" icon={Settings} />
+
+// Let IconButton handle icon sizing
+<IconButton aria-label="Add item" icon={Plus} size="xs" />
+```
+
+❌ **Don't**
+
+```tsx
+// Don't import entire icon library
+import * as Icons from '@ledgerhq/ldls-ui-react/symbols';
+
+// Don't modify icon size directly
+<IconButton aria-label="Settings">
+  <Settings size={24} />
+</IconButton>
+
+// Don't use string-based icon names
+<IconButton aria-label="Settings" icon="settings" />
+```
+
+### Layout and Styling
+
+✅ **Do**
+
+```tsx
+// Use className for layout positioning
+<IconButton
+  aria-label="Close"
+  icon={Close}
+  className="mt-4 ml-2"
+/>
+
+// Use className for positioning
+<IconButton
+  aria-label="Close"
+  icon={Close}
+  className="absolute top-0 right-0"
+/>
+
+// Use className for responsive visibility
+<IconButton
+  aria-label="Menu"
+  icon={Menu}
+  className="md:hidden"
+/>
+```
+
+❌ **Don't**
+
+```tsx
+// Don't override button's core styling
+<IconButton
+  aria-label="Settings"
+  icon={Settings}
+  className="bg-base"
+/>
+
+// Don't modify internal spacing/padding
+<IconButton
+  aria-label="Settings"
+  icon={Settings}
+  className="p-6"
+/>
+
+// Don't override icon sizing
+<IconButton
+  aria-label="Settings"
+  icon={Settings}
+  className="w-8 h-8"
+/>
+```
+
+### Performance Considerations
+
+✅ **Do**
+
+```tsx
+// Import specific icons for better tree-shaking
+import { Settings } from '@ledgerhq/ldls-ui-react/symbols';
+
+// Use appropriate size variant
+<IconButton aria-label="Settings" icon={Settings} size="xs" />
+
+// Always provide descriptive aria-labels
+<IconButton aria-label="Open settings menu" icon={Settings} />
+```
+
+❌ **Don't**
+
+```tsx
+// Don't import all icons
+import * as AllIcons from '@ledgerhq/ldls-ui-react/symbols';
+
+// Don't use custom sizes when standard ones exist
+<IconButton
+  aria-label="Settings"
+  icon={Settings}
+  className="h-[52px]"
+/>
+
+// Don't omit aria-label
+<IconButton icon={Settings} />
+```
+
+  </Tab>
+</CustomTabs>

--- a/libs/ui-react/src/lib/Components/IconButton/IconButton.stories.tsx
+++ b/libs/ui-react/src/lib/Components/IconButton/IconButton.stories.tsx
@@ -1,0 +1,279 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { IconButton } from './IconButton';
+import { Heart } from '../../Symbols/Icons/Heart';
+import { Plus } from '../../Symbols/Icons/Plus';
+import { Settings } from '../../Symbols/Icons/Settings';
+import { Share } from '../../Symbols/Icons/Share';
+import { Close } from '../../Symbols/Icons/Close';
+import { ExternalLink, Home } from '../../Symbols';
+
+const iconMap = {
+  Heart,
+  Plus,
+  Settings,
+  Share,
+  Close,
+} as const;
+
+const meta: Meta<typeof IconButton> = {
+  title: 'Action/IconButton',
+  component: IconButton,
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    icon: {
+      options: Object.keys(iconMap),
+      mapping: iconMap,
+      control: {
+        type: 'select',
+        labels: {
+          Heart: '❤️ Heart',
+          Plus: '➕ Plus',
+          Settings: '⚙️ Settings',
+          Share: '📤 Share',
+          Close: '✖️ Close',
+        },
+      },
+    },
+    'aria-label': {
+      control: 'text',
+      description:
+        'Accessible label for screen readers and fallback tooltip text',
+    },
+    appearance: {
+      control: 'select',
+      options: [
+        'base',
+        'gray',
+        'accent',
+        'transparent',
+        'no-background',
+        'red',
+      ],
+    },
+    size: {
+      control: 'select',
+      options: ['xs', 'sm', 'md', 'lg'],
+    },
+    disabled: {
+      control: 'boolean',
+    },
+    tooltip: {
+      control: 'boolean',
+      description: 'Show tooltip on hover',
+    },
+    tooltipPlacement: {
+      control: 'select',
+      options: ['top', 'right', 'bottom', 'left'],
+      description: 'Position of the tooltip relative to the button',
+    },
+    tooltipText: {
+      control: 'text',
+      description:
+        'Optional custom tooltip text (defaults to aria-label if not provided)',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof IconButton>;
+
+export const Base: Story = {
+  args: {
+    'aria-label': 'Settings',
+    icon: Settings,
+    size: 'md',
+    appearance: 'base',
+  },
+};
+
+export const AppearanceShowcase: Story = {
+  render: () => (
+    <div className='flex gap-8'>
+      <IconButton
+        aria-label='Add'
+        icon={Plus}
+        appearance='accent'
+        tooltip
+        tooltipPlacement='left'
+      />
+      <IconButton
+        aria-label='Add'
+        icon={Plus}
+        appearance='base'
+        tooltip
+        tooltipPlacement='top'
+      />
+      <IconButton
+        aria-label='Add'
+        icon={Plus}
+        appearance='gray'
+        tooltip
+        tooltipPlacement='bottom'
+      />
+      <IconButton
+        aria-label='Add'
+        icon={Plus}
+        appearance='transparent'
+        tooltip
+      />
+      <IconButton
+        aria-label='Add'
+        icon={Plus}
+        appearance='no-background'
+        tooltip
+        tooltipPlacement='bottom'
+      />
+      <IconButton
+        aria-label='Add'
+        icon={Plus}
+        appearance='red'
+        tooltip
+        tooltipPlacement='right'
+      />
+    </div>
+  ),
+};
+
+export const SizesShowcase: Story = {
+  render: () => (
+    <div className='flex items-center gap-8'>
+      <IconButton
+        aria-label='Add to favorites'
+        icon={Heart}
+        size='xs'
+        tooltip
+      />
+      <IconButton
+        aria-label='Add to favorites'
+        icon={Heart}
+        size='sm'
+        tooltip
+      />
+      <IconButton
+        aria-label='Add to favorites'
+        icon={Heart}
+        size='md'
+        tooltip
+      />
+      <IconButton
+        aria-label='Add to favorites'
+        icon={Heart}
+        size='lg'
+        tooltip
+      />
+    </div>
+  ),
+};
+
+export const StatesShowcase: Story = {
+  render: () => (
+    <div className='flex items-center gap-8'>
+      <IconButton aria-label='Settings' icon={Settings} disabled />
+      <IconButton aria-label='Settings' icon={Settings} loading />
+    </div>
+  ),
+};
+
+export const TooltipTextVariations: Story = {
+  render: () => (
+    <div className='flex flex-col gap-8'>
+      <div className='flex gap-8'>
+        <IconButton
+          aria-label='Settings'
+          icon={Settings}
+          tooltip
+          tooltipText='Configure application preferences and settings'
+        />
+        <IconButton
+          aria-label='Share'
+          icon={Share}
+          tooltip
+          tooltipText='Share this content with others'
+        />
+      </div>
+      <div className='flex gap-8'>
+        <IconButton
+          aria-label='Add to favorites'
+          icon={Heart}
+          tooltip
+          tooltipPlacement='left'
+        />
+        <IconButton
+          aria-label='Close dialog'
+          icon={Close}
+          tooltip
+          tooltipPlacement='bottom'
+        />
+      </div>
+    </div>
+  ),
+};
+
+export const AsChild: Story = {
+  render: () => {
+    const CustomLink = React.forwardRef<
+      HTMLAnchorElement,
+      React.AnchorHTMLAttributes<HTMLAnchorElement> & { to: string }
+    >(({ to, ...props }, ref) => <a ref={ref} href={to} {...props} />);
+    CustomLink.displayName = 'CustomLink';
+
+    return (
+      <div className='flex gap-8'>
+        <IconButton
+          asChild
+          aria-label='Go to home'
+          icon={Home}
+          appearance='accent'
+          tooltip
+        >
+          <CustomLink to='/' />
+        </IconButton>
+
+        <IconButton
+          asChild
+          aria-label='Go to Ledger Shop'
+          icon={ExternalLink}
+          appearance='base'
+          tooltip
+        >
+          <CustomLink
+            to='https://shop.ledger.com'
+            target='_blank'
+            rel='noopener noreferrer'
+          />
+        </IconButton>
+      </div>
+    );
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `
+        <IconButton
+          asChild
+          aria-label='Go to home'
+          icon={Home}
+          appearance='accent'
+          tooltip
+        >
+          <CustomLink to='/' />
+        </IconButton>
+
+        <IconButton
+          asChild
+          aria-label='Go to Ledger Shop'
+          icon={ExternalLink}
+          appearance='base'
+          tooltip
+        >
+          <CustomLink to='https://shop.ledger.com' />
+        </IconButton>
+
+        `,
+      },
+    },
+  },
+};

--- a/libs/ui-react/src/lib/Components/IconButton/IconButton.test.tsx
+++ b/libs/ui-react/src/lib/Components/IconButton/IconButton.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IconButton } from './IconButton';
+import { Settings } from '../../Symbols/Icons/Settings';
+
+describe('IconButton', () => {
+  it('renders with required props', () => {
+    render(<IconButton aria-label='Settings' icon={Settings} />);
+    expect(screen.getByLabelText('Settings')).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    render(
+      <IconButton
+        aria-label='Settings'
+        icon={Settings}
+        className='custom-class'
+      />,
+    );
+    expect(screen.getByLabelText('Settings')).toHaveClass('custom-class');
+  });
+
+  it('handles disabled state', () => {
+    render(<IconButton aria-label='Settings' icon={Settings} disabled />);
+    expect(screen.getByLabelText('Settings')).toBeDisabled();
+  });
+
+  it('handles click events when not disabled', async () => {
+    const handleClick = vi.fn();
+    render(
+      <IconButton
+        aria-label='Settings'
+        icon={Settings}
+        onClick={handleClick}
+      />,
+    );
+
+    await userEvent.click(screen.getByLabelText('Settings'));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not handle click events when disabled', async () => {
+    const handleClick = vi.fn();
+    render(
+      <IconButton
+        aria-label='Settings'
+        icon={Settings}
+        onClick={handleClick}
+        disabled
+      />,
+    );
+
+    await userEvent.click(screen.getByLabelText('Settings'));
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  it('renders with different sizes', () => {
+    const { rerender } = render(
+      <IconButton aria-label='Settings' icon={Settings} size='xs' />,
+    );
+    expect(screen.getByLabelText('Settings')).toHaveClass('p-8');
+
+    rerender(<IconButton aria-label='Settings' icon={Settings} size='lg' />);
+    expect(screen.getByLabelText('Settings')).toHaveClass('p-16');
+  });
+
+  it('renders with different appearances', () => {
+    const { rerender } = render(
+      <IconButton aria-label='Settings' icon={Settings} appearance='accent' />,
+    );
+    expect(screen.getByLabelText('Settings')).toHaveClass(
+      'bg-accent text-on-accent',
+    );
+
+    rerender(
+      <IconButton aria-label='Settings' icon={Settings} appearance='gray' />,
+    );
+    expect(screen.getByLabelText('Settings')).toHaveClass('bg-muted text-base');
+  });
+});

--- a/libs/ui-react/src/lib/Components/IconButton/IconButton.test.tsx
+++ b/libs/ui-react/src/lib/Components/IconButton/IconButton.test.tsx
@@ -11,13 +11,9 @@ describe('IconButton', () => {
 
   it('applies custom className', () => {
     render(
-      <IconButton
-        aria-label='Settings'
-        icon={Settings}
-        className='custom-class'
-      />,
+      <IconButton aria-label='Settings' icon={Settings} className='mt-4' />,
     );
-    expect(screen.getByLabelText('Settings')).toHaveClass('custom-class');
+    expect(screen.getByLabelText('Settings')).toHaveClass('mt-4');
   });
 
   it('handles disabled state', () => {

--- a/libs/ui-react/src/lib/Components/IconButton/IconButton.tsx
+++ b/libs/ui-react/src/lib/Components/IconButton/IconButton.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { BaseButton, BaseButtonProps } from '../Button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../Tooltip/Tooltip';
+import type * as TooltipPrimitive from '@radix-ui/react-tooltip';
+
+export interface IconButtonProps extends Omit<BaseButtonProps, 'isFull'> {
+  /**
+   * Accessible label for the IconButton
+   */
+  'aria-label': string;
+  /**
+   * The icon to display in the button
+   */
+  icon: NonNullable<BaseButtonProps['icon']>;
+  /**
+   * Whether to show a tooltip with the aria-label on hover
+   * @default false
+   */
+  tooltip?: boolean;
+  /**
+   * The preferred position of the tooltip relative to the button
+   * @default "top"
+   */
+  tooltipPlacement?: TooltipPrimitive.TooltipContentProps['side'];
+  /**
+   * Optional text to show in the tooltip. If not provided, aria-label will be used
+   */
+  tooltipText?: string;
+}
+
+export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
+  (
+    {
+      className,
+      icon,
+      tooltip = false,
+      tooltipPlacement = 'top',
+      tooltipText,
+      'aria-label': ariaLabel,
+      ...props
+    },
+    ref,
+  ) => {
+    const button = (
+      <BaseButton
+        ref={ref}
+        icon={icon}
+        className={className}
+        aria-label={ariaLabel}
+        {...props}
+      />
+    );
+
+    if (tooltip) {
+      return (
+        <Tooltip>
+          <TooltipTrigger asChild>{button}</TooltipTrigger>
+          <TooltipContent side={tooltipPlacement}>
+            {tooltipText || ariaLabel}
+          </TooltipContent>
+        </Tooltip>
+      );
+    }
+
+    return button;
+  },
+);
+
+IconButton.displayName = 'IconButton';

--- a/libs/ui-react/src/lib/Components/IconButton/index.ts
+++ b/libs/ui-react/src/lib/Components/IconButton/index.ts
@@ -1,0 +1,1 @@
+export * from './IconButton';

--- a/libs/ui-react/src/lib/Components/SheetBar/SheetBar.tsx
+++ b/libs/ui-react/src/lib/Components/SheetBar/SheetBar.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { cva } from 'class-variance-authority';
 import { cn } from '@ldls/utils-shared';
-import { Button } from '../Button';
 import { ArrowLeft, Close } from '../../Symbols';
+import { IconButton } from '../IconButton';
 
 const sheetBarVariants = cva('flex w-full bg-canvas-sheet p-16 text-base', {
   variants: {
@@ -15,7 +15,7 @@ const sheetBarVariants = cva('flex w-full bg-canvas-sheet p-16 text-base', {
 
 const BackButton = ({ onBack }: { onBack: () => void }) => {
   return (
-    <Button
+    <IconButton
       appearance='no-background'
       size='xs'
       icon={ArrowLeft}
@@ -28,7 +28,7 @@ const BackButton = ({ onBack }: { onBack: () => void }) => {
 
 const CloseButton = ({ onClose }: { onClose: () => void }) => {
   return (
-    <Button
+    <IconButton
       appearance='gray'
       size='xs'
       icon={Close}

--- a/libs/ui-react/src/lib/Components/index.ts
+++ b/libs/ui-react/src/lib/Components/index.ts
@@ -6,6 +6,7 @@ export * from './Button';
 export * from './CardButton';
 export * from './Checkbox';
 export * from './Dialog';
+export * from './IconButton';
 export * from './InteractiveIcon';
 export * from './Input';
 export * from './Link';


### PR DESCRIPTION
# Button Components Refactoring

## Issue
- Button component had mixed responsibilities handling both standard and icon-only use cases
- We need a `BaseButton` that will be our base for creating all our buttons (modal-button for instance which is coming soon )

## Solution
- Created `BaseButton` component to handle core button functionality:
  - Shared styling logic
  - Loading states
  - Accessibility features
  - Common props handling
- Built `Button` component on top of BaseButton for text/icon+text use cases.
- Created dedicated `IconButton` component extending BaseButton for icon-only interactions
- Updated documentation to clearly separate use cases between Button and IconButton

This refactoring improves maintainability, reduces code duplication, and provides clearer component boundaries for different button patterns.