### PR TITLE
feat/add formcontrol react native

### DIFF
--- a/.nx/version-plans/version-plan-1759753596014.md
+++ b/.nx/version-plans/version-plan-1759753596014.md
@@ -1,0 +1,8 @@
+---
+'@ldls/utils-shared': patch
+'@ledgerhq/ldls-design-core': patch
+'@ledgerhq/ldls-ui-rnative': patch
+'@ledgerhq/ldls-ui-react': patch
+---
+
+feat(rnative): add checkbox component + docs

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,10 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "always"
   },
+  "eslint.workingDirectories": [
+    "./libs/ui-rnative",
+    "./libs/ui-react"
+  ],
   "eslint.validate": [
       "javascriptreact",
       "typescriptreact",

--- a/libs/ui-rnative/src/lib/Components/Button/Button.tsx
+++ b/libs/ui-rnative/src/lib/Components/Button/Button.tsx
@@ -7,22 +7,22 @@ import { Spinner } from '../../Symbols';
 
 const buttonVariants = {
   root: cva(
-    'body-1-semi-bold inline-flex size-fit cursor-pointer flex-row items-center justify-center rounded-full transition-colors',
+    'inline-flex size-fit cursor-pointer flex-row items-center justify-center rounded-full transition-colors body-1-semi-bold',
     {
       variants: {
         appearance: {
           base: 'bg-interactive text-on-interactive active:bg-interactive-pressed',
-          gray: 'bg-muted active:bg-muted-pressed text-base',
+          gray: 'bg-muted text-base active:bg-muted-pressed',
           accent: 'bg-accent text-on-accent active:bg-accent-pressed',
           transparent:
-            'bg-muted-transparent active:bg-muted-transparent-pressed text-base',
+            'bg-muted-transparent text-base active:bg-muted-transparent-pressed',
           'no-background':
-            'active:bg-base-transparent-pressed bg-transparent text-base',
+            'bg-transparent text-base active:bg-base-transparent-pressed',
           red: 'bg-error text-error active:bg-error-pressed',
         },
         size: {
-          xs: 'body-2-semi-bold px-12 py-8',
-          sm: 'body-2-semi-bold px-16 py-12',
+          xs: 'px-12 py-8 body-2-semi-bold',
+          sm: 'px-16 py-12 body-2-semi-bold',
           md: 'px-16 py-12',
           lg: 'p-16',
         },
@@ -37,7 +37,7 @@ const buttonVariants = {
           false: '',
         },
         disabled: {
-          true: 'bg-disabled text-disabled active:bg-disabled pointer-events-none cursor-default',
+          true: 'pointer-events-none cursor-default bg-disabled text-disabled active:bg-disabled',
           false: '',
         },
       },
@@ -81,7 +81,7 @@ const buttonVariants = {
       },
     },
   ),
-  label: cva('body-1-semi-bold line-clamp-2 text-left text-inherit'),
+  label: cva('line-clamp-2 text-left text-inherit body-1-semi-bold'),
 };
 
 export interface ButtonProps extends Omit<TouchableOpacityProps, 'disabled'> {

--- a/libs/ui-rnative/src/lib/Components/Button/Button.tsx
+++ b/libs/ui-rnative/src/lib/Components/Button/Button.tsx
@@ -5,81 +5,84 @@ import React from 'react';
 import { cn } from '../../utils';
 import { Spinner } from '../../Symbols';
 
-const buttonVariants = cva(
-  'inline-flex size-fit cursor-pointer flex-row items-center justify-center rounded-full transition-colors body-1-semi-bold',
-  {
-    variants: {
-      appearance: {
-        base: 'bg-interactive text-on-interactive active:bg-interactive-pressed',
-        gray: 'bg-muted text-base active:bg-muted-pressed',
-        accent: 'bg-accent text-on-accent active:bg-accent-pressed',
-        transparent:
-          'bg-muted-transparent text-base active:bg-muted-transparent-pressed',
-        'no-background':
-          'bg-transparent text-base active:bg-base-transparent-pressed',
-        red: 'bg-error text-error active:bg-error-pressed',
+const buttonVariants = {
+  root: cva(
+    'body-1-semi-bold inline-flex size-fit cursor-pointer flex-row items-center justify-center rounded-full transition-colors',
+    {
+      variants: {
+        appearance: {
+          base: 'bg-interactive text-on-interactive active:bg-interactive-pressed',
+          gray: 'bg-muted active:bg-muted-pressed text-base',
+          accent: 'bg-accent text-on-accent active:bg-accent-pressed',
+          transparent:
+            'bg-muted-transparent active:bg-muted-transparent-pressed text-base',
+          'no-background':
+            'active:bg-base-transparent-pressed bg-transparent text-base',
+          red: 'bg-error text-error active:bg-error-pressed',
+        },
+        size: {
+          xs: 'body-2-semi-bold px-12 py-8',
+          sm: 'body-2-semi-bold px-16 py-12',
+          md: 'px-16 py-12',
+          lg: 'p-16',
+        },
+        isFull: {
+          true: 'w-full',
+        },
+        loading: {
+          true: '',
+        },
+        iconOnly: {
+          true: '',
+          false: '',
+        },
+        disabled: {
+          true: 'bg-disabled text-disabled active:bg-disabled pointer-events-none cursor-default',
+          false: '',
+        },
       },
-      size: {
-        xs: 'px-12 py-8 body-2-semi-bold',
-        sm: 'px-16 py-12 body-2-semi-bold',
-        md: 'px-16 py-12',
-        lg: 'p-16',
-      },
-      isFull: {
-        true: 'w-full',
-      },
-      loading: {
-        true: '',
-      },
-      iconOnly: {
-        true: '',
-        false: '',
-      },
-      disabled: {
-        true: 'pointer-events-none cursor-default bg-disabled text-disabled active:bg-disabled',
-        false: '',
-      },
-    },
-    compoundVariants: [
-      {
-        size: 'xs',
-        iconOnly: true,
-        className: 'p-8',
-      },
-      {
-        size: 'sm',
-        iconOnly: true,
-        className: 'p-12',
-      },
-      {
+      compoundVariants: [
+        {
+          size: 'xs',
+          iconOnly: true,
+          className: 'p-8',
+        },
+        {
+          size: 'sm',
+          iconOnly: true,
+          className: 'p-12',
+        },
+        {
+          size: 'md',
+          iconOnly: true,
+          className: 'p-12',
+        },
+        {
+          size: 'lg',
+          iconOnly: true,
+          className: 'p-16',
+        },
+        {
+          iconOnly: false,
+          className: 'gap-8',
+        },
+        {
+          appearance: 'no-background',
+          disabled: true,
+          className: 'bg-base-transparent',
+        },
+      ],
+      defaultVariants: {
+        appearance: 'base',
         size: 'md',
-        iconOnly: true,
-        className: 'p-12',
-      },
-      {
-        size: 'lg',
-        iconOnly: true,
-        className: 'p-16',
-      },
-      {
+        isFull: false,
         iconOnly: false,
-        className: 'gap-8',
+        disabled: false,
       },
-      {
-        appearance: 'no-background',
-        disabled: true,
-        className: 'bg-base-transparent',
-      },
-    ],
-    defaultVariants: {
-      appearance: 'base',
-      size: 'md',
-      isFull: false,
-      iconOnly: false,
-      disabled: false,
     },
-  },
-);
+  ),
+  label: cva('body-1-semi-bold line-clamp-2 text-left text-inherit'),
+};
 
 export interface ButtonProps extends Omit<TouchableOpacityProps, 'disabled'> {
   /**
@@ -180,7 +183,7 @@ export const Button = React.forwardRef<
         ref={ref}
         className={cn(
           className,
-          buttonVariants({
+          buttonVariants.root({
             appearance,
             size,
             isFull,
@@ -197,24 +200,23 @@ export const Button = React.forwardRef<
           <>
             <Spinner
               size={calculatedIconSize}
-              className='shrink-0 animate-spin'
+              className='shrink-0 animate-spin text-inherit'
               aria-label='Loading'
             />
             {children && (
-              <Text className='line-clamp-2 text-left body-1-semi-bold'>
-                {children}
-              </Text>
+              <Text className={buttonVariants.label()}>{children}</Text>
             )}
           </>
         ) : (
           <>
             {IconComponent && (
-              <IconComponent size={calculatedIconSize} className='shrink-0' />
+              <IconComponent
+                size={calculatedIconSize}
+                className='shrink-0 text-inherit'
+              />
             )}
             {children && (
-              <Text className='line-clamp-2 text-left body-1-semi-bold'>
-                {children}
-              </Text>
+              <Text className={buttonVariants.label()}>{children}</Text>
             )}
           </>
         )}

--- a/libs/ui-rnative/src/lib/Components/Checkbox/BaseCheckbox.tsx
+++ b/libs/ui-rnative/src/lib/Components/Checkbox/BaseCheckbox.tsx
@@ -14,8 +14,8 @@ import { cn } from '../../utils';
 const baseCheckboxVariants = {
   trigger: cva(
     [
-      'rounded-xs size-20 shrink-0 transition-colors',
-      'focus-visible:ring-focus focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+      'size-20 shrink-0 rounded-xs transition-colors',
+      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2',
     ],
     {
       variants: {

--- a/libs/ui-rnative/src/lib/Components/Checkbox/BaseCheckbox.tsx
+++ b/libs/ui-rnative/src/lib/Components/Checkbox/BaseCheckbox.tsx
@@ -9,13 +9,13 @@ import {
 } from '../../types';
 import { GestureResponderEvent, Pressable, View } from 'react-native';
 import { cva } from 'class-variance-authority';
-import { cn } from 'src/lib/utils';
+import { cn } from '../../utils';
 
 const baseCheckboxVariants = {
   trigger: cva(
     [
-      'size-20 shrink-0 rounded-xs transition-colors',
-      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2',
+      'rounded-xs size-20 shrink-0 transition-colors',
+      'focus-visible:ring-focus focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
     ],
     {
       variants: {

--- a/libs/ui-rnative/src/lib/Components/Checkbox/Checkbox.mdx
+++ b/libs/ui-rnative/src/lib/Components/Checkbox/Checkbox.mdx
@@ -55,9 +55,6 @@ Checkboxes support multiple states to provide clear feedback to users:
 - Provide descriptive labels for screen readers
 - Ensure sufficient color contrast in all states
 
-### Form Integration
-
-<Canvas of={CheckboxStories.FormExample} />
 
 </Tab>
 <Tab label="Implementation">

--- a/libs/ui-rnative/src/lib/Components/Checkbox/Checkbox.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/Checkbox/Checkbox.stories.tsx
@@ -89,17 +89,6 @@ export const AllStates: Story = {
           </div>
         </div>
       </div>
-      <div className='space-y-16'>
-        <h3 className='heading-4'>Required</h3>
-        <div className='space-y-8'>
-          <div className='flex items-center space-x-8'>
-            <Checkbox label='Unchecked' required defaultChecked={false} />
-          </div>
-          <div className='flex items-center space-x-8'>
-            <Checkbox label='Checked' required defaultChecked />
-          </div>
-        </div>
-      </div>
     </div>
   ),
 };

--- a/libs/ui-rnative/src/lib/Components/Checkbox/Checkbox.stories.tsx
+++ b/libs/ui-rnative/src/lib/Components/Checkbox/Checkbox.stories.tsx
@@ -14,6 +14,9 @@ const meta: Meta<typeof Checkbox> = {
       },
     },
   },
+  args: {
+    label: 'Checkbox',
+  },
   argTypes: {
     checked: {
       control: 'boolean',
@@ -30,6 +33,10 @@ const meta: Meta<typeof Checkbox> = {
     onCheckedChange: {
       action: 'checked changed',
       description: 'Callback function called when the checked state changes',
+    },
+    label: {
+      control: 'text',
+      description: 'The label text of the checkbox',
     },
   },
 };
@@ -55,17 +62,19 @@ export const Base: Story = {
  */
 export const AllStates: Story = {
   render: () => (
-    <div className='grid grid-cols-2 gap-16 p-16 text-base'>
+    <div className='grid grid-cols-3 gap-48 p-16 text-base'>
       <div className='space-y-16'>
         <h3 className='heading-4'>Enabled</h3>
         <div className='space-y-8'>
           <div className='flex items-center space-x-8'>
-            <Checkbox accessibilityLabel='Unchecked' checked={false} />
-            <span>Unchecked</span>
+            <Checkbox
+              label='Unchecked'
+              accessibilityLabel='Unchecked'
+              defaultChecked={false}
+            />
           </div>
           <div className='flex items-center space-x-8'>
-            <Checkbox checked />
-            <span>Checked</span>
+            <Checkbox label='Checked' defaultChecked />
           </div>
         </div>
       </div>
@@ -73,58 +82,24 @@ export const AllStates: Story = {
         <h3 className='heading-4'>Disabled</h3>
         <div className='space-y-8'>
           <div className='flex items-center space-x-8'>
-            <Checkbox disabled checked={false} />
-            <span className='text-muted'>Unchecked</span>
+            <Checkbox label='Unchecked' disabled defaultChecked={false} />
           </div>
           <div className='flex items-center space-x-8'>
-            <Checkbox disabled checked />
-            <span className='text-muted'>Checked</span>
+            <Checkbox label='Checked' disabled defaultChecked />
+          </div>
+        </div>
+      </div>
+      <div className='space-y-16'>
+        <h3 className='heading-4'>Required</h3>
+        <div className='space-y-8'>
+          <div className='flex items-center space-x-8'>
+            <Checkbox label='Unchecked' required defaultChecked={false} />
+          </div>
+          <div className='flex items-center space-x-8'>
+            <Checkbox label='Checked' required defaultChecked />
           </div>
         </div>
       </div>
     </div>
-  ),
-};
-
-/**
- * Example of checkbox usage in a form context.
- */
-export const FormExample: Story = {
-  render: () => (
-    <form className='space-y-16 p-16 text-base'>
-      <div className='space-y-12'>
-        <h3 className='body-1'>Subscribe to newsletters</h3>
-        <div className='space-y-8'>
-          <div className='flex items-center space-x-8'>
-            <Checkbox />
-            <label htmlFor='weekly' className='cursor-pointer body-2'>
-              Weekly newsletter
-            </label>
-          </div>
-          <div className='flex items-center space-x-8'>
-            <Checkbox />
-            <label htmlFor='monthly' className='cursor-pointer body-2'>
-              Monthly newsletter
-            </label>
-          </div>
-          <div className='flex items-center space-x-8'>
-            <Checkbox defaultChecked />
-            <label htmlFor='product-updates' className='cursor-pointer body-2'>
-              Product updates
-            </label>
-          </div>
-        </div>
-      </div>
-      <div className='flex items-center space-x-8'>
-        <Checkbox aria-label='' />
-        <label htmlFor='terms' className='cursor-pointer body-2'>
-          I agree to the{' '}
-          <a href='#' onClick={(e) => e.preventDefault()} className='underline'>
-            terms and conditions
-          </a>{' '}
-          *
-        </label>
-      </div>
-    </form>
   ),
 };

--- a/libs/ui-rnative/src/lib/Components/Checkbox/Checkbox.tsx
+++ b/libs/ui-rnative/src/lib/Components/Checkbox/Checkbox.tsx
@@ -5,6 +5,13 @@ import { BaseCheckboxIndicator, BaseCheckboxRoot } from './BaseCheckbox';
 import { Check } from '../../Symbols';
 import { CheckboxProps } from './types';
 import { useControllableState } from '../../utils';
+import { Label } from '../Label';
+import { View } from 'react-native';
+import { cva } from 'class-variance-authority';
+
+const checkboxVariants = {
+  root: cva(['flex flex-row items-center gap-8']),
+};
 
 /**
  * A customizable checkbox component built on top of Radix UI Checkbox primitive.
@@ -18,6 +25,20 @@ import { useControllableState } from '../../utils';
  * @warning The `className` prop should only be used for layout adjustments like margins or positioning.
  * Do not use it to modify the checkbox's core appearance.
  *
+ * @example
+ * import { Checkbox } from '@ledgerhq/ldls-ui-react';
+ *
+ * // Basic controlled checkbox
+ * const [checked, setChecked] = useState(false);
+ * <Checkbox
+ *   label="My label"
+ *   checked={checked}
+ *   required
+ *   onCheckedChange={setChecked}
+ * />
+ *
+ * // Uncontrolled checkbox with default state
+ * <Checkbox defaultChecked={true} onCheckedChange={handleChange} />
  */
 export const Checkbox = React.forwardRef<
   React.ElementRef<typeof BaseCheckboxRoot>,
@@ -30,6 +51,8 @@ export const Checkbox = React.forwardRef<
       onCheckedChange: onCheckedChangeProp,
       defaultChecked = false,
       disabled,
+      label,
+      required,
       ...props
     },
     ref,
@@ -41,18 +64,28 @@ export const Checkbox = React.forwardRef<
     });
 
     return (
-      <BaseCheckboxRoot
-        ref={ref}
-        disabled={disabled}
-        checked={checked}
-        onCheckedChange={onCheckedChange}
-        className={className}
-        {...props}
-      >
-        <BaseCheckboxIndicator>
-          <Check size={16} />
-        </BaseCheckboxIndicator>
-      </BaseCheckboxRoot>
+      <View className={checkboxVariants.root({ className })}>
+        <BaseCheckboxRoot
+          ref={ref}
+          disabled={disabled}
+          checked={checked}
+          onCheckedChange={onCheckedChange}
+          {...props}
+        >
+          <BaseCheckboxIndicator>
+            <Check size={16} />
+          </BaseCheckboxIndicator>
+        </BaseCheckboxRoot>
+        {label && (
+          <Label
+            disabled={disabled}
+            onPress={() => onCheckedChange(!checked)}
+            required={required}
+          >
+            {label}
+          </Label>
+        )}
+      </View>
     );
   },
 );

--- a/libs/ui-rnative/src/lib/Components/Checkbox/Checkbox.tsx
+++ b/libs/ui-rnative/src/lib/Components/Checkbox/Checkbox.tsx
@@ -33,7 +33,7 @@ const checkboxVariants = {
  * <Checkbox
  *   label="My label"
  *   checked={checked}
- *   required
+
  *   onCheckedChange={setChecked}
  * />
  *
@@ -52,7 +52,7 @@ export const Checkbox = React.forwardRef<
       defaultChecked = false,
       disabled,
       label,
-      required,
+
       ...props
     },
     ref,
@@ -77,11 +77,7 @@ export const Checkbox = React.forwardRef<
           </BaseCheckboxIndicator>
         </BaseCheckboxRoot>
         {label && (
-          <Label
-            disabled={disabled}
-            onPress={() => onCheckedChange(!checked)}
-            required={required}
-          >
+          <Label disabled={disabled} onPress={() => onCheckedChange(!checked)}>
             {label}
           </Label>
         )}

--- a/libs/ui-rnative/src/lib/Components/Checkbox/types.ts
+++ b/libs/ui-rnative/src/lib/Components/Checkbox/types.ts
@@ -6,7 +6,7 @@ export type CheckboxProps = {
    */
   disabled?: boolean;
   /**
-   * The checked state of the checkbox.
+   * The controlled checked state of the checkbox.
    */
   checked?: boolean;
   /**

--- a/libs/ui-rnative/src/lib/Components/Checkbox/types.ts
+++ b/libs/ui-rnative/src/lib/Components/Checkbox/types.ts
@@ -21,8 +21,4 @@ export type CheckboxProps = {
    * The label of the checkbox.
    */
   label?: React.ReactNode;
-  /**
-   * The required state of the checkbox.
-   */
-  required?: boolean;
 } & SlottablePressableProps;

--- a/libs/ui-rnative/src/lib/Components/Checkbox/types.ts
+++ b/libs/ui-rnative/src/lib/Components/Checkbox/types.ts
@@ -2,7 +2,7 @@ import { SlottablePressableProps } from '../../types';
 
 export type CheckboxProps = {
   /**
-   * The controlled checked state of the checkbox.
+   * The disabled state of the checkbox.
    */
   disabled?: boolean;
   /**
@@ -17,4 +17,12 @@ export type CheckboxProps = {
    * The default checked state of the checkbox.
    */
   defaultChecked?: boolean;
+  /**
+   * The label of the checkbox.
+   */
+  label?: React.ReactNode;
+  /**
+   * The required state of the checkbox.
+   */
+  required?: boolean;
 } & SlottablePressableProps;

--- a/libs/ui-rnative/src/lib/Components/Label/Label.tsx
+++ b/libs/ui-rnative/src/lib/Components/Label/Label.tsx
@@ -5,8 +5,6 @@ import { LabelProps } from './types';
 import { Text } from 'react-native';
 import { cn } from '../../utils';
 
-const REQUIRED_SYMBOL = '*';
-
 const labelVariants = cva(['body-2'], {
   variants: {
     disabled: {
@@ -24,15 +22,7 @@ const labelVariants = cva(['body-2'], {
  */
 export const Label = forwardRef<React.ElementRef<typeof Text>, LabelProps>(
   (
-    {
-      className,
-      disabled = false,
-      required = false,
-      children,
-      onPress,
-      onLongPress,
-      ...props
-    },
+    { className, disabled = false, children, onPress, onLongPress, ...props },
     ref,
   ) => {
     return (
@@ -43,7 +33,7 @@ export const Label = forwardRef<React.ElementRef<typeof Text>, LabelProps>(
         className={cn(labelVariants({ disabled }), className)}
         {...props}
       >
-        {children} {required && REQUIRED_SYMBOL}
+        {children}
       </Text>
     );
   },

--- a/libs/ui-rnative/src/lib/Components/Label/Label.tsx
+++ b/libs/ui-rnative/src/lib/Components/Label/Label.tsx
@@ -3,7 +3,7 @@ import React, { forwardRef } from 'react';
 import { cva } from 'class-variance-authority';
 import { LabelProps } from './types';
 import { Text } from 'react-native';
-import { cn } from 'src/lib/utils';
+import { cn } from '../../utils';
 
 const REQUIRED_SYMBOL = '*';
 
@@ -24,14 +24,22 @@ const labelVariants = cva(['body-2'], {
  */
 export const Label = forwardRef<React.ElementRef<typeof Text>, LabelProps>(
   (
-    { className, disabled = false, required = false, children, ...props },
+    {
+      className,
+      disabled = false,
+      required = false,
+      children,
+      onPress,
+      onLongPress,
+      ...props
+    },
     ref,
   ) => {
     return (
       <Text
         disabled={disabled}
-        onPress={disabled ? undefined : props.onPress}
-        onLongPress={disabled ? undefined : props.onLongPress}
+        onPress={disabled ? undefined : onPress}
+        onLongPress={disabled ? undefined : onLongPress}
         className={cn(labelVariants({ disabled }), className)}
         {...props}
       >
@@ -41,4 +49,4 @@ export const Label = forwardRef<React.ElementRef<typeof Text>, LabelProps>(
   },
 );
 
-Label.displayName = 'LabelProps';
+Label.displayName = 'Label';

--- a/libs/ui-rnative/src/lib/Components/Label/Label.tsx
+++ b/libs/ui-rnative/src/lib/Components/Label/Label.tsx
@@ -1,0 +1,44 @@
+import React, { forwardRef } from 'react';
+
+import { cva } from 'class-variance-authority';
+import { LabelProps } from './types';
+import { Text } from 'react-native';
+import { cn } from 'src/lib/utils';
+
+const REQUIRED_SYMBOL = '*';
+
+const labelVariants = cva(['body-2'], {
+  variants: {
+    disabled: {
+      true: 'text-disabled',
+      false: 'text-base',
+    },
+  },
+});
+
+/**
+ * A label that should be used to describe a form field.
+ *
+ * Either choices fields like checkbox, switch or radio.
+ * Or text fields like input, textarea, select, etc.
+ */
+export const Label = forwardRef<React.ElementRef<typeof Text>, LabelProps>(
+  (
+    { className, disabled = false, required = false, children, ...props },
+    ref,
+  ) => {
+    return (
+      <Text
+        disabled={disabled}
+        onPress={disabled ? undefined : props.onPress}
+        onLongPress={disabled ? undefined : props.onLongPress}
+        className={cn(labelVariants({ disabled }), className)}
+        {...props}
+      >
+        {children} {required && REQUIRED_SYMBOL}
+      </Text>
+    );
+  },
+);
+
+Label.displayName = 'LabelProps';

--- a/libs/ui-rnative/src/lib/Components/Label/index.ts
+++ b/libs/ui-rnative/src/lib/Components/Label/index.ts
@@ -1,0 +1,1 @@
+export * from './Label';

--- a/libs/ui-rnative/src/lib/Components/Label/types.ts
+++ b/libs/ui-rnative/src/lib/Components/Label/types.ts
@@ -1,0 +1,12 @@
+import { TextProps } from 'react-native';
+
+export type LabelProps = {
+  /**
+   * The disabled state of the label.
+   */
+  disabled?: boolean;
+  /**
+   * The required state of the checkbox.
+   */
+  required?: boolean;
+} & TextProps;

--- a/libs/ui-rnative/src/lib/Components/Label/types.ts
+++ b/libs/ui-rnative/src/lib/Components/Label/types.ts
@@ -6,7 +6,7 @@ export type LabelProps = {
    */
   disabled?: boolean;
   /**
-   * The required state of the checkbox.
+   * The required state of the label.
    */
   required?: boolean;
 } & TextProps;

--- a/libs/ui-rnative/src/lib/Components/Label/types.ts
+++ b/libs/ui-rnative/src/lib/Components/Label/types.ts
@@ -5,8 +5,4 @@ export type LabelProps = {
    * The disabled state of the label.
    */
   disabled?: boolean;
-  /**
-   * The required state of the label.
-   */
-  required?: boolean;
 } & TextProps;

--- a/libs/ui-rnative/src/lib/Components/Tag/Tag.tsx
+++ b/libs/ui-rnative/src/lib/Components/Tag/Tag.tsx
@@ -53,7 +53,7 @@ export const Tag = React.forwardRef<View, TagProps>(
         {IconComponent && (
           <IconComponent size={calculatedIconSize} className='shrink-0' />
         )}
-        <Text>{label}</Text>
+        <Text className='text-inherit'>{label}</Text>
       </View>
     );
   },

--- a/libs/ui-rnative/src/lib/Components/index.ts
+++ b/libs/ui-rnative/src/lib/Components/index.ts
@@ -3,3 +3,4 @@ export * from './CardButton';
 export * from './ListItem';
 export * from './Spot';
 export * from './Tag';
+export * from './Checkbox';

--- a/libs/ui-rnative/src/styles.css
+++ b/libs/ui-rnative/src/styles.css
@@ -2,9 +2,3 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Reset React Native Web Text defaults to allow inheritance */
-.css-146c3p1,
-.css-text-146c3p1 {
-  font-family: inherit !important;
-  color: inherit !important;
-}


### PR DESCRIPTION
## Description
Add a label and required prop to the checkbox.
Abstract the Label in its own component for now, so it can be re-used for the Switch (and radio?)

- chore(eslint): fix known issue with config of tailwind eslint
- feat(rnative): extend Checkbox API to support label and required props
- feat(rnative): add Label component
- refactor(rnative): remove generated storybook classnames, instead just add text-inherits to components