### PR TITLE
chore/make utils shared publishable lib 2

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build ui-react library
         env:
           NX_NO_CLOUD: true
-        run: npx nx build @ldls/ui-react --skip-nx-cache
+        run: npx nx build @ledgerhq/ldls-ui-react --skip-nx-cache
 
       - name: Build Storybook
         env:

--- a/.nx/version-plans/version-plan-1759845129146.md
+++ b/.nx/version-plans/version-plan-1759845129146.md
@@ -1,5 +1,5 @@
 ---
-'@ldls/utils-shared': patch
+'@ledgerhq/ldls-utils-shared': patch
 ---
 
 Initial boostrap of the library

--- a/.nx/version-plans/version-plan-1759851299902.md
+++ b/.nx/version-plans/version-plan-1759851299902.md
@@ -1,0 +1,9 @@
+---
+'@ledgerhq/ldls-utils-shared': patch
+'@ledgerhq/ldls-design-core': patch
+'@ledgerhq/ldls-ui-rnative': patch
+'@ledgerhq/ldls-ui-react': patch
+'@ledgerhq/ldls-ui-core': patch
+---
+
+Chore: nxjs tooling changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,31 +19,27 @@ The LDLS Design System is structured as a monorepo using Nx, with the following 
 ldls
   ├──libs/
   │    ├── ui-core/        # Shared utilities and types
-  │    │                   # nx: @ldls/ui-core
+  │    │                   # name: @ledgerhq/ldls-ui-core
   │    │
   │    ├── ui-react/       # React components
-  │    │                   # nx: @ldls/ui-react
-  │    │                   # npm-package: @ledgerhq/ldls-ui-react
+  │    │                   # name: @ledgerhq/ldls-ui-react
   │    │
   │    ├── ui-rnative/     # React Native components
-  │    │                   # nx: @ldls/ui-rnative
-  │    │                   # npm-package: @ledgerhq/ldls-ui-rnative
+  │    │                   # name: @ledgerhq/ldls-ui-rnative
   │    │
   │    ├── design-core/    # Design tokens and themes
-  │    │                   # nx: @ldls/design-core
-  │    │                   # npm-package: @ledgerhq/ldls-design-core
+  │    │                   # name: @ledgerhq/ldls-design-core
   │    │
   │    └── utils-shared/   # Shared utilities
-  │                        # nx: @ldls/utils-shared
-  │                        # npm-package: @ledgerhq/ldls-utils-shared
+  │                        # name: @ledgerhq/ldls-utils-shared
   │
   └──apps/
        ├── app-sandbox-rnative   # Demo React-Native application
        └── app-sandbox-react     # Demo React application
 ```
 
-- NXJS libraries are prefixed by `@ldls/*` - defined in the project.json
-- Publishable npm libraries are prefixed by `@ledgerhq/ldls-*` - defined in the package.json
+- NXJS libraries are prefixed by `@ledgerhq/ldls-*` - defined in the project.json
+- NPM package will match the name of the NXJS library, to make a library publishable a private:false needs to be set
 
 ### Technology Stack
 
@@ -91,7 +87,7 @@ npx nx run @ledgerhq/ldls-ui-react:build
 npx nx run @ledgerhq/ldls-ui-rnative:build
 
 # Build shared core library
-npx nx run @ldls/ui-core:build
+npx nx run @ledgerhq/ldls-ui-core:build
 ```
 
 ### Branch Strategy

--- a/libs/design-core/project.json
+++ b/libs/design-core/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ldls/design-core",
+  "name": "@ledgerhq/ldls-design-core",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/design-core/src",
   "projectType": "library",

--- a/libs/ui-core/jest.config.ts
+++ b/libs/ui-core/jest.config.ts
@@ -9,7 +9,7 @@ const swcJestConfig = JSON.parse(
 swcJestConfig.swcrc = false;
 
 export default {
-  displayName: '@ldls/ui-core',
+  displayName: '@ledgerhq/ldls-ui-core',
   preset: '../../jest.preset.js',
   testEnvironment: 'node',
   transform: {

--- a/libs/ui-core/package.json
+++ b/libs/ui-core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ldls/ui-core",
+  "name": "@ledgerhq/ldls-ui-core",
   "version": "0.0.2",
   "private": true,
   "type": "module",

--- a/libs/ui-core/project.json
+++ b/libs/ui-core/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ldls/ui-core",
+  "name": "@ledgerhq/ldls-ui-core",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/ui-core/src",
   "projectType": "library",

--- a/libs/ui-react/project.json
+++ b/libs/ui-react/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ldls/ui-react",
+  "name": "@ledgerhq/ldls-ui-react",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/ui-react/src",
   "projectType": "library",

--- a/libs/ui-rnative/project.json
+++ b/libs/ui-rnative/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ldls/ui-rnative",
+  "name": "@ledgerhq/ldls-ui-rnative",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/ui-rnative/src",
   "projectType": "library",

--- a/libs/utils-shared/README.md
+++ b/libs/utils-shared/README.md
@@ -15,13 +15,13 @@ Shared utility functions for the LDLS design system.
 
 ```bash
 # Build the library
-npx nx build ldls-utils-shared
+npx nx build @ledgerhq/ldls-utils-shared
 
 # Run tests
-npx nx test ldls-utils-shared
+npx nx test @ledgerhq/ldls-utils-shared
 
 # Lint code
-npx nx lint ldls-utils-shared
+npx nx lint @ledgerhq/ldls-utils-shared
 ```
 
 ### Guidelines

--- a/libs/utils-shared/project.json
+++ b/libs/utils-shared/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ldls/utils-shared",
+  "name": "@ledgerhq/ldls-utils-shared",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/utils-shared/src",
   "projectType": "library",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@ldls/source",
+  "name": "@ledgerhq/ldls-source",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@ldls/source",
+      "name": "@ledgerhq/ldls-source",
       "version": "0.0.0",
       "license": "Apache-2.0",
       "workspaces": [
@@ -200,7 +200,7 @@
       }
     },
     "libs/ui-core": {
-      "name": "@ldls/ui-core",
+      "name": "@ledgerhq/ldls-ui-core",
       "version": "0.0.2"
     },
     "libs/ui-react": {
@@ -4422,12 +4422,12 @@
         "tslib": "2"
       }
     },
-    "node_modules/@ldls/ui-core": {
-      "resolved": "libs/ui-core",
-      "link": true
-    },
     "node_modules/@ledgerhq/ldls-design-core": {
       "resolved": "libs/design-core",
+      "link": true
+    },
+    "node_modules/@ledgerhq/ldls-ui-core": {
+      "resolved": "libs/ui-core",
       "link": true
     },
     "node_modules/@ledgerhq/ldls-ui-react": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ldls/source",
+  "name": "@ledgerhq/ldls-source",
   "version": "0.0.0",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Desc
The nx lib and package name have to use the same name for `nx release` to work.
Unfortunatelly we can't have separate naming for better understanding

- **chore: completely remove /@ldls prefix for libs - keep it consistent with package name**
- **chore: nx release plan**
